### PR TITLE
Design: Color Assets 추가

### DIFF
--- a/Kabinett/Assets.xcassets/Color/Alert.colorset/Contents.json
+++ b/Kabinett/Assets.xcassets/Color/Alert.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.188",
+          "green" : "0.231",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Kabinett/Assets.xcassets/Color/Background.colorset/Contents.json
+++ b/Kabinett/Assets.xcassets/Color/Background.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.867",
+          "green" : "0.910",
+          "red" : "0.925"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Kabinett/Assets.xcassets/Color/ContentPrimary.colorset/Contents.json
+++ b/Kabinett/Assets.xcassets/Color/ContentPrimary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.208",
+          "green" : "0.208",
+          "red" : "0.208"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Kabinett/Assets.xcassets/Color/ContentSecondary.colorset/Contents.json
+++ b/Kabinett/Assets.xcassets/Color/ContentSecondary.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.478",
+          "green" : "0.478",
+          "red" : "0.478"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/Kabinett/Assets.xcassets/Color/Contents.json
+++ b/Kabinett/Assets.xcassets/Color/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Kabinett/Assets.xcassets/Color/Primary300.colorset/Contents.json
+++ b/Kabinett/Assets.xcassets/Color/Primary300.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.745",
+          "green" : "0.780",
+          "red" : "0.780"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Kabinett/Assets.xcassets/Color/Primary600.colorset/Contents.json
+++ b/Kabinett/Assets.xcassets/Color/Primary600.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.404",
+          "green" : "0.424",
+          "red" : "0.424"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Kabinett/Assets.xcassets/Color/Primary900.colorset/Contents.json
+++ b/Kabinett/Assets.xcassets/Color/Primary900.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.169",
+          "green" : "0.169",
+          "red" : "0.169"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Kabinett/Assets.xcassets/Color/Secondary900.colorset/Contents.json
+++ b/Kabinett/Assets.xcassets/Color/Secondary900.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.016",
+          "green" : "0.000",
+          "red" : "0.827"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #35 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] Color Assets 추가


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

```swift
let color = Color.primary900
```
애셋에 화면에 필요한 컬러들을 넣어두었어요. 이렇게 사용하시면 되어요. 개발하다가 애셋에 없는 컬러를 발견하시면 신고해주세요.

<br/><br/>