### PR TITLE
Feature/UserSearchUpdate Letter

### DIFF
--- a/Kabinett/Domain/Entity/Letter.swift
+++ b/Kabinett/Domain/Entity/Letter.swift
@@ -25,5 +25,5 @@ struct Letter: Codable, Identifiable {
     let photoContents: [String]
     let date: Date
     let stationeryImageUrlString: String?
-    let isRead: Bool
+    var isRead: Bool
 }

--- a/Kabinett/Domain/UseCase/LetterBoxUseCase/LetterBoxUseCase.swift
+++ b/Kabinett/Domain/UseCase/LetterBoxUseCase/LetterBoxUseCase.swift
@@ -14,6 +14,9 @@ protocol LetterBoxUseCase {
     
     func searchBy(userId: String, findKeyword: String, letterType: LetterType) async -> Result<[Letter]?, any Error>
     func searchBy(userId: String, letterType: LetterType, startDate: Date, endDate: Date) async -> Result<[Letter]?, any Error>
+    
+    func removeLetter(userId: String, letterId: String, letterType: LetterType) async -> Result<Bool, any Error>
+    func updateIsRead(userId: String, letterId: String, letterType: LetterType) async -> Result<Bool, any Error>
 }
 
 enum LetterType {


### PR DESCRIPTION
### 📕 Issue Number

Close #32 Close #44


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

유저 Letter 검색/삭제/업데이트 구현

- [x] 검색 관련 Protocol 작성
- [x] 유저 이름/KabinettNumber 검색
- [x] 특정 기간 검색
- [x] 유저 편지 삭제, 업데이트 protocol 작성
- [x] 유저 편지 삭제 구현
- [x] 유저 편지 수정 구현 (open 한 경우 읽음으로 변경)


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

1. Letter SearchBy Keyword
- name, KabinettNumber로 관련 편지 검색 가능
- name이 변경되거나, KabinettNumber가 새로 생기는 경우 과거 Letter 정보 변경되지 않음

2. Letter Entity 변경
- isRead의 경우 변경이 가능해야하므로(읽음/안읽음) var로 변경

3. Sent Collection에 저장되는 경우 isRead = true 처리

4. Letter isRead 업데이트 기능 구현
- Letter가 update 되기 전 삭제가 될 수 있으므로 validateLetter 메소드 구현

5. Letter 삭제 기능 구현

+)
updateIsRead와 removeLetter의 do-catch 문 중 
error가 발생해도 catch에서 error를 통과한 후 한 번에 에러가 있는지 확인하기 위해(.all의 경우) catch를 비워두었습니다.
catch에 쓸 코드를 찾지 못해 우선 빈 칸으로 남겨두었습니다.
넣을만한 코드가 있다면 추천해주세요!

<br/><br/>