### PR TITLE
Feature/LoadLetterStuff

### DIFF
--- a/Kabinett.xcodeproj/project.pbxproj
+++ b/Kabinett.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		AFA58F242C6A02BF00A7C569 /* ComponentsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA58F232C6A02BF00A7C569 /* ComponentsUseCase.swift */; };
 		AFA58F262C6AE33D00A7C569 /* FirebaseLetterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA58F252C6AE33D00A7C569 /* FirebaseLetterService.swift */; };
 		AFA58F302C6C4B2A00A7C569 /* LetterBoxUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA58F2F2C6C4B2A00A7C569 /* LetterBoxUseCase.swift */; };
+		AFDE7D2A2C75791E0019F2DE /* LetterWriteLoadStuffUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDE7D292C75791E0019F2DE /* LetterWriteLoadStuffUseCase.swift */; };
+		AFDE7D2C2C75792E0019F2DE /* ComponentsLoadStuffUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDE7D2B2C75792E0019F2DE /* ComponentsLoadStuffUseCase.swift */; };
+		AFDE7D2E2C75797A0019F2DE /* FirebaseStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDE7D2D2C75797A0019F2DE /* FirebaseStorageManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +93,9 @@
 		AFA58F232C6A02BF00A7C569 /* ComponentsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsUseCase.swift; sourceTree = "<group>"; };
 		AFA58F252C6AE33D00A7C569 /* FirebaseLetterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseLetterService.swift; sourceTree = "<group>"; };
 		AFA58F2F2C6C4B2A00A7C569 /* LetterBoxUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterBoxUseCase.swift; sourceTree = "<group>"; };
+		AFDE7D292C75791E0019F2DE /* LetterWriteLoadStuffUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LetterWriteLoadStuffUseCase.swift; sourceTree = "<group>"; };
+		AFDE7D2B2C75792E0019F2DE /* ComponentsLoadStuffUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentsLoadStuffUseCase.swift; sourceTree = "<group>"; };
+		AFDE7D2D2C75797A0019F2DE /* FirebaseStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseStorageManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -134,8 +140,8 @@
 		831401392C69C21300F601FB /* ComponentsUseCase */ = {
 			isa = PBXGroup;
 			children = (
+				AFDE7D2B2C75792E0019F2DE /* ComponentsLoadStuffUseCase.swift */,
 				AFA58F232C6A02BF00A7C569 /* ComponentsUseCase.swift */,
-				AFF423EA2C75749C005697D8 /* ComponentsLoadStuffUseCase.swift */,
 			);
 			path = ComponentsUseCase;
 			sourceTree = "<group>";
@@ -152,7 +158,7 @@
 			isa = PBXGroup;
 			children = (
 				AFA58F212C6A004C00A7C569 /* LetterWriteUseCase.swift */,
-				AFF423E42C748EFF005697D8 /* LetterWriteLoadStuffUseCase.swift */,
+				AFDE7D292C75791E0019F2DE /* LetterWriteLoadStuffUseCase.swift */,
 			);
 			path = LetterWriteUseCase;
 			sourceTree = "<group>";
@@ -345,6 +351,7 @@
 			isa = PBXGroup;
 			children = (
 				AFA58F252C6AE33D00A7C569 /* FirebaseLetterService.swift */,
+				AFDE7D2D2C75797A0019F2DE /* FirebaseStorageManager.swift */,
 			);
 			path = Firebase;
 			sourceTree = "<group>";
@@ -561,13 +568,15 @@
 				AFA58F262C6AE33D00A7C569 /* FirebaseLetterService.swift in Sources */,
 				AFA58F302C6C4B2A00A7C569 /* LetterBoxUseCase.swift in Sources */,
 				AFA58F222C6A004C00A7C569 /* LetterWriteUseCase.swift in Sources */,
-				AFF423E52C748EFF005697D8 /* LetterWriteLoadStuffUseCase.swift in Sources */,
 				8314013F2C69C34500F601FB /* Letter.swift in Sources */,
 				57EBE5B92C6B399C003ECD7F /* StationerySelectionView.swift in Sources */,
 				57EBE5B42C6AE818003ECD7F /* DummyData.swift in Sources */,
+				AFDE7D2A2C75791E0019F2DE /* LetterWriteLoadStuffUseCase.swift in Sources */,
 				57EBE5B02C69E5F2003ECD7F /* UserSelectionView.swift in Sources */,
+				AFDE7D2E2C75797A0019F2DE /* FirebaseStorageManager.swift in Sources */,
 				839CE0F92C644BEF003635F3 /* ContentView.swift in Sources */,
 				57EBE5BD2C6C43A7003ECD7F /* LetterWriteViewModel.swift in Sources */,
+				AFDE7D2C2C75792E0019F2DE /* ComponentsLoadStuffUseCase.swift in Sources */,
 				57EBE5B62C6AF149003ECD7F /* SearchBar.swift in Sources */,
 				57EBE5B22C69E653003ECD7F /* ModalTestView.swift in Sources */,
 				839CE0F72C644BEF003635F3 /* KabinettApp.swift in Sources */,

--- a/Kabinett.xcodeproj/project.pbxproj
+++ b/Kabinett.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 			isa = PBXGroup;
 			children = (
 				AFA58F212C6A004C00A7C569 /* LetterWriteUseCase.swift */,
+				AFF423E42C748EFF005697D8 /* LetterWriteLoadStuffUseCase.swift */,
 			);
 			path = LetterWriteUseCase;
 			sourceTree = "<group>";
@@ -559,6 +560,7 @@
 				AFA58F262C6AE33D00A7C569 /* FirebaseLetterService.swift in Sources */,
 				AFA58F302C6C4B2A00A7C569 /* LetterBoxUseCase.swift in Sources */,
 				AFA58F222C6A004C00A7C569 /* LetterWriteUseCase.swift in Sources */,
+				AFF423E52C748EFF005697D8 /* LetterWriteLoadStuffUseCase.swift in Sources */,
 				8314013F2C69C34500F601FB /* Letter.swift in Sources */,
 				57EBE5B92C6B399C003ECD7F /* StationerySelectionView.swift in Sources */,
 				57EBE5B42C6AE818003ECD7F /* DummyData.swift in Sources */,

--- a/Kabinett.xcodeproj/project.pbxproj
+++ b/Kabinett.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				AFA58F232C6A02BF00A7C569 /* ComponentsUseCase.swift */,
+				AFF423EA2C75749C005697D8 /* ComponentsLoadStuffUseCase.swift */,
 			);
 			path = ComponentsUseCase;
 			sourceTree = "<group>";

--- a/Kabinett/Domain/UseCase/ComponentsUseCase/ComponentsLoadStuffUseCase.swift
+++ b/Kabinett/Domain/UseCase/ComponentsUseCase/ComponentsLoadStuffUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  ComponentsLoadStuffUseCase.swift
+//  Kabinett
+//
+//  Created by JIHYE SEOK on 8/21/24.
+//
+
+import Foundation
+
+protocol ComponentsLoadStuffUseCase {
+    func loadEnvelopes() async -> Result<[String], any Error>
+    func loadStamps() async -> Result<[String], any Error>
+}

--- a/Kabinett/Domain/UseCase/LetterWriteUseCase/LetterWriteLoadStuffUseCase.swift
+++ b/Kabinett/Domain/UseCase/LetterWriteUseCase/LetterWriteLoadStuffUseCase.swift
@@ -1,0 +1,14 @@
+//
+//  LoadLetterStuffUseCase.swift
+//  Kabinett
+//
+//  Created by JIHYE SEOK on 8/20/24.
+//
+
+import Foundation
+
+protocol LetterWriteLoadStuffUseCase {
+    func loadEnvelopes() async -> Result<[String], any Error>
+    func loadStamps() async -> Result<[String], any Error>
+    func loadStationeries() async -> Result<[String], any Error>
+}

--- a/Kabinett/Service/Firebase/FirebaseStorageManager.swift
+++ b/Kabinett/Service/Firebase/FirebaseStorageManager.swift
@@ -1,0 +1,42 @@
+//
+//  FirebaseStorageManager.swift
+//  Kabinett
+//
+//  Created by JIHYE SEOK on 8/21/24.
+//
+
+import Foundation
+import FirebaseStorage
+
+final class FirebaseStorageManager: LetterWriteLoadStuffUseCase, ComponentsLoadStuffUseCase, ObservableObject {
+    let storage = Storage.storage()
+    
+    func loadEnvelopes() async -> Result<[String], any Error> {
+        let envelopeRef = storage.reference().child("Envelopes")
+        
+        do {
+            let envelopes = try await envelopeRef.listAll()
+            var envelopeURLStrings: [String] = []
+            for envelope in envelopes.items {
+                let envelopeURL = try await envelope.downloadURL()
+                envelopeURLStrings.append(envelopeURL.absoluteString)
+            }
+            
+            return .success(envelopeURLStrings)
+        } catch {
+            return .failure(error)
+        }
+    }
+    
+    func loadStamps() async -> Result<[String], any Error> {
+        // TODO: - stamp loading
+        fatalError()
+    }
+    
+    func loadStationeries() async -> Result<[String], any Error> {
+        // TODO: - stationery loading
+        fatalError()
+    }
+    
+    
+}

--- a/Kabinett/Service/Firebase/FirebaseStorageManager.swift
+++ b/Kabinett/Service/Firebase/FirebaseStorageManager.swift
@@ -8,55 +8,35 @@
 import Foundation
 import FirebaseStorage
 
-final class FirebaseStorageManager: LetterWriteLoadStuffUseCase, ComponentsLoadStuffUseCase, ObservableObject {
+final class FirebaseStorageManager: LetterWriteLoadStuffUseCase, ComponentsLoadStuffUseCase {
     let storage = Storage.storage()
     
+    // 편지봉투 로딩
     func loadEnvelopes() async -> Result<[String], any Error> {
-        let envelopeRef = storage.reference().child("Envelopes")
-        
-        do {
-            let envelopes = try await envelopeRef.listAll()
-            var envelopeURLStrings: [String] = []
-            for envelope in envelopes.items {
-                let envelopeURL = try await envelope.downloadURL()
-                envelopeURLStrings.append(envelopeURL.absoluteString)
-            }
-            
-            return .success(envelopeURLStrings)
-        } catch {
-            return .failure(error)
-        }
+        await loadStorage(path: "Envelopes")
     }
     
+    // 우표 로딩
     func loadStamps() async -> Result<[String], any Error> {
-        let stampRef = storage.reference().child("Stamps")
-        
-        do {
-            let stamps = try await stampRef.listAll()
-            var stampURLStrings: [String] = []
-            for stamp in stamps.items {
-                let stampURL = try await stamp.downloadURL()
-                stampURLStrings.append(stampURL.absoluteString)
-            }
-            
-            return .success(stampURLStrings)
-        } catch {
-            return .failure(error)
-        }
+        await loadStorage(path: "Stamps")
     }
     
+    // 편지지 로딩
     func loadStationeries() async -> Result<[String], any Error> {
-        let stationeryRef = storage.reference().child("Stationeries")
+        await loadStorage(path: "Stationeries")
+    }
+    
+    private func loadStorage(path: String) async -> Result<[String], any Error> {
+        let storageRef = storage.reference().child(path)
         
         do {
-            let stationeries = try await stationeryRef.listAll()
-            var stationeryURLStrings: [String] = []
-            for stationery in stationeries.items {
-                let stationeryURL = try await stationery.downloadURL()
-                stationeryURLStrings.append(stationeryURL.absoluteString)
+            let results = try await storageRef.listAll()
+            var resultURLStrings: [String] = []
+            for result in results.items {
+                let resultURL = try await result.downloadURL()
+                resultURLStrings.append(resultURL.absoluteString)
             }
-            
-            return .success(stationeryURLStrings)
+            return .success(resultURLStrings)
         } catch {
             return .failure(error)
         }

--- a/Kabinett/Service/Firebase/FirebaseStorageManager.swift
+++ b/Kabinett/Service/Firebase/FirebaseStorageManager.swift
@@ -29,8 +29,20 @@ final class FirebaseStorageManager: LetterWriteLoadStuffUseCase, ComponentsLoadS
     }
     
     func loadStamps() async -> Result<[String], any Error> {
-        // TODO: - stamp loading
-        fatalError()
+        let stampRef = storage.reference().child("Stamps")
+        
+        do {
+            let stamps = try await stampRef.listAll()
+            var stampURLStrings: [String] = []
+            for stamp in stamps.items {
+                let stampURL = try await stamp.downloadURL()
+                stampURLStrings.append(stampURL.absoluteString)
+            }
+            
+            return .success(stampURLStrings)
+        } catch {
+            return .failure(error)
+        }
     }
     
     func loadStationeries() async -> Result<[String], any Error> {

--- a/Kabinett/Service/Firebase/FirebaseStorageManager.swift
+++ b/Kabinett/Service/Firebase/FirebaseStorageManager.swift
@@ -46,8 +46,20 @@ final class FirebaseStorageManager: LetterWriteLoadStuffUseCase, ComponentsLoadS
     }
     
     func loadStationeries() async -> Result<[String], any Error> {
-        // TODO: - stationery loading
-        fatalError()
+        let stationeryRef = storage.reference().child("Stationeries")
+        
+        do {
+            let stationeries = try await stationeryRef.listAll()
+            var stationeryURLStrings: [String] = []
+            for stationery in stationeries.items {
+                let stationeryURL = try await stationery.downloadURL()
+                stationeryURLStrings.append(stationeryURL.absoluteString)
+            }
+            
+            return .success(stationeryURLStrings)
+        } catch {
+            return .failure(error)
+        }
     }
     
     


### PR DESCRIPTION
### 📕 Issue Number

Close #33


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

편지지, 편지봉투, 우표 정보 storage 로딩
- [x] 편지지, 편지봉투, 우표 정보 로딩 usecase 작성
- [x] 편지봉투 로딩
- [x] 편지지 로딩
- [x] 우표 로딩


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

FireStorage에서 편지봉투, 우표, 편지지 정보를 로딩할 수 있습니다.
출력 값은 URL 형태의 String 배열입니다.

FireStorage에 Envelopes(편지봉투), Stamps(우표), Stationeries(편지지) 폴더를 생성해 놓았으니,
파일이 완성된다면 추가해주시면 됩니다~!

<br/><br/>