### PR TITLE
Feature/FirebasePhotoManager

### DIFF
--- a/Kabinett/Service/Firebase/FirebaseLetterService.swift
+++ b/Kabinett/Service/Firebase/FirebaseLetterService.swift
@@ -487,7 +487,7 @@ final class FirebaseLetterService: LetterWriteUseCase, ComponentsUseCase, Letter
         
         do {
             for photoContent in photoContents {
-                let photoRef = storageRef.child("PhotoContents/images/\(UUID().uuidString).jpg")
+                let photoRef = storageRef.child("Users/photoContents/\(UUID().uuidString).jpg")
                 
                 _ = try await photoRef.putDataAsync(photoContent, metadata: nil)
                 


### PR DESCRIPTION
### 📕 Issue Number

Close #55


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

photoContents를 Storage에 저장한 뒤 해당 URL을 firestore에 저장하는 방식으로 변경

- [x] photoContents 관련 타입 변경
- [x] storage 이미지 저장 및 URL 다운로드 코드 작성
- [x] Letter save 코드 수정


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

<동작 Flow>
1. photoContents: [Data]로 이미지를 전달합니다.
  - LetterWrite의 경우 빈 배열이어도 상관 없음
2. 빈 배열이 아닌 경우, Storage에 저장합니다.
3. Storage에 저장된 사진 파일을 url 형태의 [String]으로 받아옵니다.
4. AsyncImage로 사진을 조회할 수 있습니다.

+)
photoContents를 저장하는 Storage의 경로를 Users/photoContents로 지정하였습니다.
추후 편지지, 우표 등 커스텀이 가능할 때 Users/{~~} 경로로 저장을 한다면 좋을 것 같아서요 !
이건 아닌거 같은데 싶으면 편하게 말씀주세요, 앱 출시 전까지는 얼마든지 바꿔도 괜찮아요~

<br/><br/>