### PR TITLE
Feature/login and profile_ SignUp 결과 화면 분기 

### DIFF
--- a/Kabinett.xcodeproj/project.pbxproj
+++ b/Kabinett.xcodeproj/project.pbxproj
@@ -384,12 +384,9 @@
 				04DEC0E62C6C6C7300D289EA /* ProfileView.swift */,
 				04DEC0E82C6C799500D289EA /* SettingsView.swift */,
 				04DEC0EC2C6C882100D289EA /* ProfileSettingsView.swift */,
+				04DEC0EA2C6C87B500D289EA /* AccountSettingsView.swift */,
 				04DEC0FB2C7D96BC00D289EA /* ImageCropper.swift */,
 				04DEC0F92C75863600D289EA /* CropBox.swift */,
-				04DEC0EA2C6C87B500D289EA /* AccountSettingsView.swift */,
-				04DEC0DC2C6A3AD600D289EA /* LoginView.swift */,
-				04DEC0E02C6AFA7500D289EA /* SignUpNameInputView.swift */,
-				04DEC0E22C6B2E1C00D289EA /* SignUpKabinettNumberSelectView.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -397,6 +394,9 @@
 		8366B6F52C65ECF70021FAE0 /* SignUp */ = {
 			isa = PBXGroup;
 			children = (
+				04DEC0DC2C6A3AD600D289EA /* LoginView.swift */,
+				04DEC0E02C6AFA7500D289EA /* SignUpNameInputView.swift */,
+				04DEC0E22C6B2E1C00D289EA /* SignUpKabinettNumberSelectView.swift */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";
@@ -438,7 +438,6 @@
 			isa = PBXGroup;
 			children = (
 				04DEC0F12C6E18EE00D289EA /* ProfileSettingsViewModel.swift */,
-				04DEC0F32C6F171E00D289EA /* SignUpViewModel.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -446,6 +445,7 @@
 		8366B6FA2C65ED1A0021FAE0 /* SignUp */ = {
 			isa = PBXGroup;
 			children = (
+				04DEC0F32C6F171E00D289EA /* SignUpViewModel.swift */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";

--- a/Kabinett.xcodeproj/project.pbxproj
+++ b/Kabinett.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		04DEC0F82C7423F300D289EA /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 04DEC0F72C7423F200D289EA /* Settings.bundle */; };
 		04DEC0FA2C75863700D289EA /* CropBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DEC0F92C75863600D289EA /* CropBox.swift */; };
 		04DEC0FC2C7D96BC00D289EA /* ImageCropper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DEC0FB2C7D96BC00D289EA /* ImageCropper.swift */; };
+		04DEC0FE2C7EDB1100D289EA /* KabinettNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DEC0FD2C7EDB1100D289EA /* KabinettNumberFormatter.swift */; };
 		530912CC2C7045F200964130 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530912CB2C7045F200964130 /* ToastView.swift */; };
 		530C765A2C7638D9007E09C6 /* LetterBoxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530C76592C7638D9007E09C6 /* LetterBoxViewModel.swift */; };
 		530C765C2C76CEFC007E09C6 /* LetterBoxUseCaseStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530C765B2C76CEFC007E09C6 /* LetterBoxUseCaseStub.swift */; };
@@ -125,6 +126,7 @@
 		04DEC0F72C7423F200D289EA /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		04DEC0F92C75863600D289EA /* CropBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBox.swift; sourceTree = "<group>"; };
 		04DEC0FB2C7D96BC00D289EA /* ImageCropper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCropper.swift; sourceTree = "<group>"; };
+		04DEC0FD2C7EDB1100D289EA /* KabinettNumberFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KabinettNumberFormatter.swift; sourceTree = "<group>"; };
 		530912CB2C7045F200964130 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		530C76592C7638D9007E09C6 /* LetterBoxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterBoxViewModel.swift; sourceTree = "<group>"; };
 		530C765B2C76CEFC007E09C6 /* LetterBoxUseCaseStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterBoxUseCaseStub.swift; sourceTree = "<group>"; };
@@ -446,6 +448,7 @@
 			isa = PBXGroup;
 			children = (
 				04DEC0F32C6F171E00D289EA /* SignUpViewModel.swift */,
+				04DEC0FD2C7EDB1100D289EA /* KabinettNumberFormatter.swift */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";
@@ -746,6 +749,7 @@
 				AFCFDFC32C7C3F2A00BEFFDF /* DefaultProfileUseCase.swift in Sources */,
 				AFCFDFC42C7C3F2A00BEFFDF /* FirebaseFirestoreManager.swift in Sources */,
 				577157052C75DD9900E21162 /* Writer.swift in Sources */,
+				04DEC0FE2C7EDB1100D289EA /* KabinettNumberFormatter.swift in Sources */,
 				83F0D6872C7072DB001B8733 /* FirestoreWriterManager.swift in Sources */,
 				577156FB2C7578FE00E21162 /* WriteLetterView.swift in Sources */,
 				577156FD2C7584E000E21162 /* NavigationBarView.swift in Sources */,

--- a/Kabinett.xcodeproj/project.pbxproj
+++ b/Kabinett.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		04DEC0F42C6F171E00D289EA /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DEC0F32C6F171E00D289EA /* SignUpViewModel.swift */; };
 		04DEC0F82C7423F300D289EA /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 04DEC0F72C7423F200D289EA /* Settings.bundle */; };
 		04DEC0FA2C75863700D289EA /* CropBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DEC0F92C75863600D289EA /* CropBox.swift */; };
+		04DEC0FC2C7D96BC00D289EA /* ImageCropper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DEC0FB2C7D96BC00D289EA /* ImageCropper.swift */; };
 		530912CC2C7045F200964130 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530912CB2C7045F200964130 /* ToastView.swift */; };
 		530C765A2C7638D9007E09C6 /* LetterBoxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530C76592C7638D9007E09C6 /* LetterBoxViewModel.swift */; };
 		530C765C2C76CEFC007E09C6 /* LetterBoxUseCaseStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530C765B2C76CEFC007E09C6 /* LetterBoxUseCaseStub.swift */; };
@@ -123,6 +124,7 @@
 		04DEC0F32C6F171E00D289EA /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
 		04DEC0F72C7423F200D289EA /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		04DEC0F92C75863600D289EA /* CropBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBox.swift; sourceTree = "<group>"; };
+		04DEC0FB2C7D96BC00D289EA /* ImageCropper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCropper.swift; sourceTree = "<group>"; };
 		530912CB2C7045F200964130 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		530C76592C7638D9007E09C6 /* LetterBoxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterBoxViewModel.swift; sourceTree = "<group>"; };
 		530C765B2C76CEFC007E09C6 /* LetterBoxUseCaseStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterBoxUseCaseStub.swift; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 				04DEC0E62C6C6C7300D289EA /* ProfileView.swift */,
 				04DEC0E82C6C799500D289EA /* SettingsView.swift */,
 				04DEC0EC2C6C882100D289EA /* ProfileSettingsView.swift */,
+				04DEC0FB2C7D96BC00D289EA /* ImageCropper.swift */,
 				04DEC0F92C75863600D289EA /* CropBox.swift */,
 				04DEC0EA2C6C87B500D289EA /* AccountSettingsView.swift */,
 				04DEC0DC2C6A3AD600D289EA /* LoginView.swift */,
@@ -800,6 +803,7 @@
 				577157042C75DC3B00E21162 /* Extension+Font.swift in Sources */,
 				57EBE5B22C69E653003ECD7F /* ModalTestView.swift in Sources */,
 				839CE0F72C644BEF003635F3 /* KabinettApp.swift in Sources */,
+				04DEC0FC2C7D96BC00D289EA /* ImageCropper.swift in Sources */,
 				7F7868482C782F820083D204 /* TabBarButton.swift in Sources */,
 				577157012C75D73700E21162 /* Extension+UIApplication.swift in Sources */,
 				832C72672C71CF7B0071E8D0 /* SignUpUseCase.swift in Sources */,

--- a/Kabinett/Application/KabinettApp.swift
+++ b/Kabinett/Application/KabinettApp.swift
@@ -42,8 +42,7 @@ struct KabinettApp: App {
     
     var body: some Scene {
         WindowGroup {
-//            ContentView()
-            SignUpNameInputView(viewModel: SignUpViewModel(signUpUseCase: SignUpUseCaseStub()))
+            ContentView()
         }
     }
 }

--- a/Kabinett/Application/KabinettApp.swift
+++ b/Kabinett/Application/KabinettApp.swift
@@ -42,7 +42,8 @@ struct KabinettApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
+//            ContentView()
+            SignUpNameInputView(viewModel: SignUpViewModel(signUpUseCase: SignUpUseCaseStub()))
         }
     }
 }

--- a/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
+++ b/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
@@ -18,3 +18,25 @@ protocol ProfileUseCase {
     func signout() async -> Bool
     func deleteId() async -> Bool
 }
+
+final class ProfileUseCaseStub: ProfileUseCase {
+    func isAnonymous() async -> AnyPublisher<Bool, Never> {
+        Just(false)
+            .eraseToAnyPublisher()
+    }
+    func getCurrentWriter() async -> Writer {
+        return Writer(
+            name: "Yule",
+            kabinettNumber: 455444,
+            profileImage: nil)
+    }
+    func updateWriter(newWriterName: String, profileImage: Data?) async -> Bool {
+        true
+    }
+    func signout() async -> Bool {
+        false
+    }
+    func deleteId() async -> Bool {
+        false
+    }
+}

--- a/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
+++ b/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
@@ -11,6 +11,7 @@ import Combine
 protocol ProfileUseCase {
     func isAnonymous() async -> AnyPublisher<Bool, Never>
     func getCurrentWriter() async -> Writer
+    func getAppleID() async -> String
     func updateWriter(
         newWriterName: String,
         profileImage: Data?
@@ -30,6 +31,11 @@ final class ProfileUseCaseStub: ProfileUseCase {
             kabinettNumber: 455444,
             profileImage: nil)
     }
+
+    func getAppleID() async -> String {
+        "figfigure13@gmail.com"
+    }
+    
     func updateWriter(newWriterName: String, profileImage: Data?) async -> Bool {
         true
     }

--- a/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
+++ b/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
@@ -31,6 +31,6 @@ final class SignUpUseCaseStub: SignupUseCase {
     func startLoginUser(with userName: String, kabinettNumber: Int) async -> Bool {
         print("Received userName in UseCase: \(userName)")
         print("Received Kabinett Number in UseCase: \(kabinettNumber)")
-        return false
+        return true
     }
 }

--- a/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
+++ b/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
@@ -29,6 +29,8 @@ final class SignUpUseCaseStub: SignupUseCase {
     }
     
     func startLoginUser(with userName: String, kabinettNumber: Int) async -> Bool {
-        true
+        print("Received userName in UseCase: \(userName)")
+        print("Received Kabinett Number in UseCase: \(kabinettNumber)")
+        return false
     }
 }

--- a/Kabinett/Presentation/ContentView.swift
+++ b/Kabinett/Presentation/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
             // + OptionOverlay Button
             Color.clear
             
-            ProfileView(viewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
+            ProfileView(profileViewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
                 .tag(2)
         }
     }

--- a/Kabinett/Presentation/ContentView.swift
+++ b/Kabinett/Presentation/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
             // + OptionOverlay Button
             Color.clear
             
-            ProfileView(viewModel: ProfileSettingsViewModel())
+            ProfileView(viewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
                 .tag(2)
         }
     }

--- a/Kabinett/Presentation/View/Components/CustomTabView/CustomTabView.swift
+++ b/Kabinett/Presentation/View/Components/CustomTabView/CustomTabView.swift
@@ -27,7 +27,7 @@ struct CustomTabView<Content: View>: View {
             TabView(selection: $customTabViewModel.selectedTab) {
                 content
             }
-            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+//            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
             
             VStack {
                 Spacer()

--- a/Kabinett/Presentation/View/Profile/AccountSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/AccountSettingsView.swift
@@ -29,6 +29,7 @@ struct AccountSettingsView: View {
                         }
                         .padding(.top, 20)
                         .padding(.horizontal, geometry.size.width * 0.06)
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(PlainButtonStyle())
                     .contentShape(Rectangle())
@@ -47,6 +48,7 @@ struct AccountSettingsView: View {
                                 .foregroundColor(.contentSecondary)
                         }
                         .padding(.horizontal, geometry.size.width * 0.06)
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(PlainButtonStyle())
                     .contentShape(Rectangle())

--- a/Kabinett/Presentation/View/Profile/AccountSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/AccountSettingsView.swift
@@ -32,7 +32,6 @@ struct AccountSettingsView: View {
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(PlainButtonStyle())
-                    .contentShape(Rectangle())
                     
                     Spacer()
                     
@@ -51,7 +50,6 @@ struct AccountSettingsView: View {
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(PlainButtonStyle())
-                    .contentShape(Rectangle())
                 }
                 .navigationBarBackButtonHidden(true)
                 .toolbar {

--- a/Kabinett/Presentation/View/Profile/CropBox.swift
+++ b/Kabinett/Presentation/View/Profile/CropBox.swift
@@ -65,7 +65,7 @@ public struct CropBox: View {
                         self.frameSize = geometry.size
                         self.centerCropBox()
                     }
-                    .onChange(of: geometry.size) { newSize in
+                    .onChange(of: geometry.size) { oldSize, newSize in
                         self.frameSize = newSize
                         self.centerCropBox()
                     }

--- a/Kabinett/Presentation/View/Profile/ImageCropper.swift
+++ b/Kabinett/Presentation/View/Profile/ImageCropper.swift
@@ -1,0 +1,92 @@
+//
+//  ImageCropper.swift
+//  Kabinett
+//
+//  Created by Yule on 8/27/24.
+//
+
+import SwiftUI
+
+struct ImageCropper: View {
+    @ObservedObject var viewModel: ProfileSettingsViewModel
+    @Binding var isShowingCropper: Bool
+    let image: UIImage?
+    @State var cropArea: CGRect = .init(x: 0, y: 0, width: 110, height: 110)
+    @State var imageViewSize: CGSize = .zero
+    @State var croppedImage: UIImage? = nil
+
+    var body: some View {
+        if let image = image {
+            VStack {
+                Spacer()
+                imageView(image: image)
+                Spacer()
+                actionButtons(image: image)
+                if let croppedImage = croppedImage {
+                    croppedImageView(croppedImage: croppedImage)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.black)
+        } else {
+            Text("No image available for cropping.")
+        }
+    }
+
+    @ViewBuilder
+    private func imageView(image: UIImage) -> some View {
+        Image(uiImage: image)
+            .resizable()
+            .scaledToFit()
+            .overlay(alignment: .topLeading) {
+                GeometryReader { geometry in
+                    CropBox(rect: $cropArea)
+                        .onAppear {
+                            self.imageViewSize = geometry.size
+                        }
+                        .onChange(of: geometry.size) {
+                            self.imageViewSize = geometry.size
+                        }
+                }
+            }
+    }
+
+    @ViewBuilder
+    private func actionButtons(image: UIImage) -> some View {
+        HStack {
+            Button(action: {
+                isShowingCropper = false
+            }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 20))
+                    .foregroundColor(.white)
+            }
+
+            Spacer()
+
+            Text("이미지 자르기")
+                .foregroundColor(.white)
+
+            Spacer()
+
+            Button(action: {
+                viewModel.crop(image: image, cropArea: cropArea, imageViewSize: imageViewSize)
+                croppedImage = viewModel.croppedImage
+            }) {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 20))
+                    .foregroundColor(.white)
+            }
+        }
+        .frame(width: 350)
+        .padding(.bottom, 10)
+    }
+
+    @ViewBuilder
+    private func croppedImageView(croppedImage: UIImage) -> some View {
+        Image(uiImage: croppedImage)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 110)
+    }
+}

--- a/Kabinett/Presentation/View/Profile/ImageCropper.swift
+++ b/Kabinett/Presentation/View/Profile/ImageCropper.swift
@@ -44,7 +44,7 @@ struct ImageCropper: View {
                         .onAppear {
                             self.imageViewSize = geometry.size
                         }
-                        .onChange(of: geometry.size) {
+                        .onChange(of: geometry.size) { oldValue, newValue in
                             self.imageViewSize = geometry.size
                         }
                 }

--- a/Kabinett/Presentation/View/Profile/ImageCropper.swift
+++ b/Kabinett/Presentation/View/Profile/ImageCropper.swift
@@ -44,7 +44,7 @@ struct ImageCropper: View {
                         .onAppear {
                             self.imageViewSize = geometry.size
                         }
-                        .onChange(of: geometry.size) { oldValue, newValue in
+                        .onChange(of: geometry.size) { _, _ in
                             self.imageViewSize = geometry.size
                         }
                 }

--- a/Kabinett/Presentation/View/Profile/ImageCropper.swift
+++ b/Kabinett/Presentation/View/Profile/ImageCropper.swift
@@ -10,18 +10,18 @@ import SwiftUI
 struct ImageCropper: View {
     @ObservedObject var viewModel: ProfileSettingsViewModel
     @Binding var isShowingCropper: Bool
-    let image: UIImage?
+    let imageToCrop: UIImage?
     @State var cropArea: CGRect = .init(x: 0, y: 0, width: 110, height: 110)
     @State var imageViewSize: CGSize = .zero
     @State var croppedImage: UIImage? = nil
 
     var body: some View {
-        if let image = image {
+        if let imageToCrop = imageToCrop {
             VStack {
                 Spacer()
-                imageView(image: image)
+                imageView(image: imageToCrop)
                 Spacer()
-                actionButtons(image: image)
+                actionButtons(image: imageToCrop)
                 if let croppedImage = croppedImage {
                     croppedImageView(croppedImage: croppedImage)
                 }

--- a/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import PhotosUI
 
 struct ProfileSettingsView: View {
-    @StateObject var viewModel: ProfileSettingsViewModel
+    @ObservedObject var viewModel: ProfileSettingsViewModel
     @Environment(\.dismiss) var dismiss
     @Binding var shouldNavigateToProfileView: Bool
     

--- a/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
@@ -56,16 +56,9 @@ struct ProfileSettingsView: View {
         .sheet(isPresented: $viewModel.isShowingCropper) {
             if let profileImage = viewModel.selectedImage {
                 ImageCropper(viewModel: viewModel, isShowingCropper: $viewModel.isShowingCropper, image: profileImage)
-            } else {
-                Text("No image available for cropping.")
             }
         }
         .onDisappear {
-            if shouldNavigateToProfileView {
-                DispatchQueue.main.async {
-                    shouldNavigateToProfileView = true
-                }
-            }
             if !viewModel.isProfileUpdated {
                 viewModel.croppedImage = nil
             }

--- a/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
@@ -55,7 +55,7 @@ struct ProfileSettingsView: View {
         }
         .sheet(isPresented: $viewModel.isShowingCropper) {
             if let profileImage = viewModel.selectedImage {
-                ImageCropper(viewModel: viewModel, isShowingCropper: $viewModel.isShowingCropper, image: profileImage)
+                ImageCropper(viewModel: viewModel, isShowingCropper: $viewModel.isShowingCropper, imageToCrop: profileImage)
             }
         }
         .onDisappear {

--- a/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
@@ -18,47 +18,6 @@ struct ProfileSettingsView: View {
             VStack{
                 photoPickerView()
                 userInfoInputFields()
-                //                    ZStack{
-                //                        Circle()
-                //                            .foregroundColor(.primary300)
-                //                            .frame(width: 110, height: 110)
-                //                        if let image: UIImage = viewModel.croppedImage {
-                //                            Image(uiImage: image)
-                //                                .resizable()
-                //                                .scaledToFill()
-                //                                .frame(width: 110, height: 110)
-                //                                .clipShape(Circle())
-                //                        }
-                //                        Image(systemName: "photo")
-                //                            .font(.system(size: 36))
-                //                            .foregroundColor(.white)
-                //                    }
-                //                }
-                //                .onChange(of: viewModel.selectedImageItem) { newItem in
-                //                    Task {
-                //                        if let data = try? await newItem?.loadTransferable(type: Data.self),
-                //                           let uiImage = UIImage(data: data) {
-                //                            viewModel.selectedImage = uiImage
-                //                            viewModel.isShowingCropper = true
-                //                        }
-                //                    }
-                //                }
-                //                .padding(.bottom, 10)
-                //
-                //                TextField(viewModel.displayName, text: $viewModel.newUserName)
-                //                    .textFieldStyle(ProfileOvalTextFieldStyle())
-                //                    .autocorrectionDisabled(true)
-                //                    .keyboardType(.alphabet)
-                //                    .submitLabel(.done)
-                //                    .frame(alignment: .center)
-                //                    .multilineTextAlignment(.center)
-                //                    .font(Font.system(size: 25, design: .default))
-                //                    .padding(.bottom, 10)
-                //
-                //                Text(viewModel.kabinettNumber)
-                //                    .fontWeight(.light)
-                //                    .font(.system(size: 16))
-                //                    .monospaced()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.background)
@@ -137,20 +96,9 @@ struct ProfileSettingsView: View {
             }
         }
         .onChange(of: viewModel.selectedImageItem) { oldItem, newItem in
-            handleImageSelection(newItem: newItem)
+            viewModel.handleImageSelection(newItem: newItem)
         }
         .padding(.bottom, 10)
-    }
-    
-    private func handleImageSelection(newItem: PhotosPickerItem?) {
-        Task {
-            if let item = newItem,
-               let data = try? await item.loadTransferable(type: Data.self),
-               let uiImage = UIImage(data: data) {
-                viewModel.selectedImage = uiImage
-                viewModel.isShowingCropper = true
-            }
-        }
     }
     
     @ViewBuilder

--- a/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
@@ -10,58 +10,55 @@ import PhotosUI
 
 struct ProfileSettingsView: View {
     @StateObject var viewModel: ProfileSettingsViewModel
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
     @Binding var shouldNavigateToProfileView: Bool
     
     var body: some View {
         NavigationStack {
             VStack{
-                PhotosPicker(
-                    selection: $viewModel.selectedImageItem,
-                    matching: .images,
-                    photoLibrary: .shared()
-                ) {
-                    ZStack{
-                        Circle()
-                            .foregroundColor(.primary300)
-                            .frame(width: 110, height: 110)
-                        if let image = viewModel.croppedImage {
-                            Image(uiImage: image)
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: 110, height: 110)
-                                .clipShape(Circle())
-                        }
-                        Image(systemName: "photo")
-                            .font(.system(size: 36))
-                            .foregroundColor(.white)
-                    }
-                }
-                .onChange(of: viewModel.selectedImageItem) { newItem in
-                    Task {
-                        if let data = try? await newItem?.loadTransferable(type: Data.self),
-                           let uiImage = UIImage(data: data) {
-                            viewModel.selectedImage = uiImage
-                            viewModel.isShowingCropper = true
-                        }
-                    }
-                }
-                .padding(.bottom, 10)
-                
-                TextField(viewModel.displayName, text: $viewModel.newUserName)
-                    .textFieldStyle(ProfileOvalTextFieldStyle())
-                    .autocorrectionDisabled(true)
-                    .keyboardType(.alphabet)
-                    .submitLabel(.done)
-                    .frame(alignment: .center)
-                    .multilineTextAlignment(.center)
-                    .font(Font.system(size: 25, design: .default))
-                    .padding(.bottom, 10)
-                
-                Text(viewModel.kabinettNumber)
-                    .fontWeight(.light)
-                    .font(.system(size: 16))
-                    .monospaced()
+                photoPickerView()
+                userInfoInputFields()
+                //                    ZStack{
+                //                        Circle()
+                //                            .foregroundColor(.primary300)
+                //                            .frame(width: 110, height: 110)
+                //                        if let image: UIImage = viewModel.croppedImage {
+                //                            Image(uiImage: image)
+                //                                .resizable()
+                //                                .scaledToFill()
+                //                                .frame(width: 110, height: 110)
+                //                                .clipShape(Circle())
+                //                        }
+                //                        Image(systemName: "photo")
+                //                            .font(.system(size: 36))
+                //                            .foregroundColor(.white)
+                //                    }
+                //                }
+                //                .onChange(of: viewModel.selectedImageItem) { newItem in
+                //                    Task {
+                //                        if let data = try? await newItem?.loadTransferable(type: Data.self),
+                //                           let uiImage = UIImage(data: data) {
+                //                            viewModel.selectedImage = uiImage
+                //                            viewModel.isShowingCropper = true
+                //                        }
+                //                    }
+                //                }
+                //                .padding(.bottom, 10)
+                //
+                //                TextField(viewModel.displayName, text: $viewModel.newUserName)
+                //                    .textFieldStyle(ProfileOvalTextFieldStyle())
+                //                    .autocorrectionDisabled(true)
+                //                    .keyboardType(.alphabet)
+                //                    .submitLabel(.done)
+                //                    .frame(alignment: .center)
+                //                    .multilineTextAlignment(.center)
+                //                    .font(Font.system(size: 25, design: .default))
+                //                    .padding(.bottom, 10)
+                //
+                //                Text(viewModel.kabinettNumber)
+                //                    .fontWeight(.light)
+                //                    .font(.system(size: 16))
+                //                    .monospaced()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.background)
@@ -71,7 +68,7 @@ struct ProfileSettingsView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(action: {
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                     }) {
                         HStack {
                             Image(systemName: "chevron.left")
@@ -86,7 +83,7 @@ struct ProfileSettingsView: View {
                     Button(action: {
                         viewModel.completeProfileUpdate()
                         shouldNavigateToProfileView = true
-                        presentationMode.wrappedValue.dismiss()
+                        dismiss()
                     }) {
                         Text("완료")
                             .fontWeight(.medium)
@@ -116,110 +113,81 @@ struct ProfileSettingsView: View {
             viewModel.selectedImageItem = nil
         }
     }
-}
-
-struct ProfileOvalTextFieldStyle: TextFieldStyle {
-    func _body(configuration: TextField<Self._Label>) -> some View {
-        configuration
-            .padding(10)
-            .background(
-                Capsule()
-                    .stroke(Color.primary300, lineWidth: 1)
-                    .background(Capsule().fill(Color.white))
-            )
-            .frame(width: 270, height: 54)
-    }
-}
-
-struct ImageCropper: View {
-    @ObservedObject var viewModel: ProfileSettingsViewModel
-    @Binding var isShowingCropper: Bool
-    let image: UIImage?
-    @State var cropArea: CGRect = .init(x: 0, y:0, width: 110, height: 110)
-    @State var imageViewSize: CGSize = .zero
-    @State var croppedImage: UIImage?
-    
-    var body: some View {
-        if let image = image {
-            VStack {
-                Spacer()
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .overlay(alignment: .topLeading) {
-                        GeometryReader { geometry in
-                            CropBox(rect: $cropArea)
-                                .onAppear {
-                                    self.imageViewSize = geometry.size
-                                }
-                                .onChange(of: geometry.size) {
-                                    self.imageViewSize = $0
-                                }
-                        }
-                    }
-                Spacer()
-                    .overlay(alignment: .bottom) {
-                        HStack {
-                            Button(action: {
-                                isShowingCropper = false
-                            }) {
-                                Image(systemName: "xmark")
-                                    .font(.system(size: 20))
-                                    .foregroundColor(.white)
-                            }
-                            
-                            Spacer()
-                            
-                            Text("이미지 자르기")
-                                .foregroundColor(.white)
-                            
-                            Spacer()
-                            
-                            Button(action: {
-                                let croppedImage = self.crop(image: image, cropArea: cropArea, imageViewSize: imageViewSize)
-                                viewModel.croppedImage = croppedImage
-                                isShowingCropper = false
-                            }) {
-                                Image(systemName: "checkmark")
-                                    .font(.system(size: 20))
-                                    .foregroundColor(.white)
-                            }
-                        }
-                        .frame(width: 350) // 이렇게 상수로 넣지않으면 면적 확보가 안됨
-                        .padding(.bottom, 10)
-                    }
-                if let croppedImage {
-                    Image(uiImage: croppedImage)
+    @ViewBuilder
+    private func photoPickerView() -> some View {
+        PhotosPicker(
+            selection: $viewModel.selectedImageItem,
+            matching: .images,
+            photoLibrary: .shared()
+        ) {
+            ZStack {
+                Circle()
+                    .foregroundColor(.primary300)
+                    .frame(width: 110, height: 110)
+                if let image = viewModel.croppedImage {
+                    Image(uiImage: image)
                         .resizable()
-                        .scaledToFit()
-                        .frame(width: 110)
+                        .scaledToFill()
+                        .frame(width: 110, height: 110)
+                        .clipShape(Circle())
                 }
+                Image(systemName: "photo")
+                    .font(.system(size: 36))
+                    .foregroundColor(.white)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(.black)
-        } else {
-            Text("No image available for cropping.")
+        }
+        .onChange(of: viewModel.selectedImageItem) { oldItem, newItem in
+            handleImageSelection(newItem: newItem)
+        }
+        .padding(.bottom, 10)
+    }
+    
+    private func handleImageSelection(newItem: PhotosPickerItem?) {
+        Task {
+            if let item = newItem,
+               let data = try? await item.loadTransferable(type: Data.self),
+               let uiImage = UIImage(data: data) {
+                viewModel.selectedImage = uiImage
+                viewModel.isShowingCropper = true
+            }
         }
     }
     
-    private func crop(image: UIImage, cropArea: CGRect, imageViewSize: CGSize) -> UIImage? {
-        let scaleX = image.size.width / imageViewSize.width * image.scale
-        let scaleY = image.size.height / imageViewSize.height * image.scale
-        let scaledCropArea = CGRect(
-            x: cropArea.origin.x * scaleX,
-            y: cropArea.origin.y * scaleY,
-            width: cropArea.size.width * scaleX,
-            height: cropArea.size.height * scaleY
-        )
-        
-        guard let cutImageRef: CGImage =
-                image.cgImage?.cropping(to: scaledCropArea) else {
-            return nil
+    @ViewBuilder
+    private func userInfoInputFields() -> some View {
+        VStack {
+            TextField(viewModel.displayName, text: $viewModel.newUserName)
+                .textFieldStyle(ProfileOvalTextFieldStyle())
+                .autocorrectionDisabled(true)
+                .keyboardType(.alphabet)
+                .submitLabel(.done)
+                .frame(alignment: .center)
+                .multilineTextAlignment(.center)
+                .font(Font.system(size: 25, design: .default))
+                .padding(.bottom, 10)
+            
+            Text(viewModel.formattedKabinettNumber)
+                .fontWeight(.light)
+                .font(.system(size: 16))
+                .monospaced()
         }
-        
-        return UIImage(cgImage: cutImageRef)
+    }
+    
+    struct ProfileOvalTextFieldStyle: TextFieldStyle {
+        func _body(configuration: TextField<Self._Label>) -> some View {
+            configuration
+                .padding(10)
+                .background(
+                    Capsule()
+                        .stroke(Color.primary300, lineWidth: 1)
+                        .background(Capsule().fill(Color.white))
+                )
+                .frame(width: 270, height: 54)
+        }
     }
 }
+
+
 
 //#Preview {
 //    ProfileSettingsView(viewModel: ProfileSettingsViewModel(), shouldNavigateToProfileView: <#Binding<Bool>#>)

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct ProfileView: View {
-    @StateObject var viewModel: ProfileSettingsViewModel
+    @StateObject var profileViewModel: ProfileSettingsViewModel
     
     var body: some View {
         GeometryReader { geometry in
             NavigationStack {
                 VStack{
-                    if let image = viewModel.profileImage {
+                    if let image = profileViewModel.profileImage {
                         Image(uiImage: image)
                             .resizable()
                             .scaledToFill()
@@ -28,11 +28,11 @@ struct ProfileView: View {
                             .padding(.bottom, -1)
                     }
                     
-                    Text(viewModel.userName)
+                    Text(profileViewModel.userName)
                         .fontWeight(.regular)
                         .font(.system(size: 36))
                         .padding(.bottom, 0.1)
-                    Text(viewModel.formattedKabinettNumber)
+                    Text(profileViewModel.formattedKabinettNumber)
                         .fontWeight(.light)
                         .font(.system(size: 16))
                         .monospaced()
@@ -43,7 +43,7 @@ struct ProfileView: View {
                 .navigationBarBackButtonHidden()
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        NavigationLink(destination: SettingsView(viewModel: viewModel)) {
+                        NavigationLink(destination: SettingsView(profileViewModel: profileViewModel)) {
                             Image(systemName: "gearshape")
                                 .fontWeight(.medium)
                                 .font(.system(size: 19))
@@ -56,5 +56,5 @@ struct ProfileView: View {
     }
 }
 #Preview {
-    ProfileView(viewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
+    ProfileView(profileViewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
 }

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -32,7 +32,7 @@ struct ProfileView: View {
                         .fontWeight(.regular)
                         .font(.system(size: 36))
                         .padding(.bottom, 0.1)
-                    Text(viewModel.kabinettNumber)
+                    Text(viewModel.formattedKabinettNumber)
                         .fontWeight(.light)
                         .font(.system(size: 16))
                         .monospaced()
@@ -55,5 +55,5 @@ struct ProfileView: View {
     }
 }
 #Preview {
-    ProfileView(viewModel: ProfileSettingsViewModel())
+    ProfileView(viewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
 }

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct ProfileView: View {
     @StateObject var viewModel: ProfileSettingsViewModel
-    var shouldHideBackButton: Bool = false
     
     var body: some View {
         GeometryReader { geometry in
@@ -41,7 +40,7 @@ struct ProfileView: View {
                 .padding(.horizontal, geometry.size.width * 0.06)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.background)
-                .navigationBarBackButtonHidden(shouldHideBackButton)
+                .navigationBarBackButtonHidden()
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         NavigationLink(destination: SettingsView(viewModel: viewModel)) {

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ProfileView: View {
     @StateObject var viewModel: ProfileSettingsViewModel
+    var shouldHideBackButton: Bool = false
     
     var body: some View {
         GeometryReader { geometry in
@@ -40,6 +41,7 @@ struct ProfileView: View {
                 .padding(.horizontal, geometry.size.width * 0.06)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.background)
+                .navigationBarBackButtonHidden(shouldHideBackButton)
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         NavigationLink(destination: SettingsView(viewModel: viewModel)) {

--- a/Kabinett/Presentation/View/Profile/SettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/SettingsView.swift
@@ -91,5 +91,5 @@ struct SettingsView: View {
 }
 
 #Preview {
-    SettingsView(viewModel: ProfileSettingsViewModel())
+    SettingsView(viewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
 }

--- a/Kabinett/Presentation/View/Profile/SettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/SettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @StateObject var viewModel: ProfileSettingsViewModel
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
     @State private var shouldNavigateToProfileView = false
     
     var body: some View {
@@ -75,7 +75,7 @@ struct SettingsView: View {
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button(action: {
-                            presentationMode.wrappedValue.dismiss()
+                            dismiss()
                         }) {
                             HStack {
                                 Image(systemName: "chevron.left")

--- a/Kabinett/Presentation/View/Profile/SettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/SettingsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @StateObject var viewModel: ProfileSettingsViewModel
+    @ObservedObject var profileViewModel: ProfileSettingsViewModel
     @Environment(\.dismiss) var dismiss
     @State private var shouldNavigateToProfileView = false
     
@@ -16,7 +16,7 @@ struct SettingsView: View {
         GeometryReader { geometry in
             NavigationStack {
                 VStack(alignment: .leading) {
-                    NavigationLink(destination: ProfileSettingsView(viewModel: viewModel, shouldNavigateToProfileView: $shouldNavigateToProfileView)) {
+                    NavigationLink(destination: ProfileSettingsView(viewModel: profileViewModel, shouldNavigateToProfileView: $shouldNavigateToProfileView)) {
                         HStack{
                             Text("프로필 설정")
                                 .fontWeight(.medium)
@@ -60,7 +60,7 @@ struct SettingsView: View {
                                 .foregroundColor(.white)
                         }
                         .padding(.leading, 10)
-                        Text(viewModel.appleID)
+                        Text(profileViewModel.appleID)
                             .font(.system(size: 17))
                             .foregroundColor(.contentSecondary)
                     }
@@ -93,5 +93,5 @@ struct SettingsView: View {
 }
 
 #Preview {
-    SettingsView(viewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
+    SettingsView(profileViewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
 }

--- a/Kabinett/Presentation/View/Profile/SettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/SettingsView.swift
@@ -30,6 +30,7 @@ struct SettingsView: View {
                         .padding(.top, 20)
                         .padding(.bottom, 30)
                         .padding(.horizontal, geometry.size.width * 0.06)
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(PlainButtonStyle())
                     
@@ -45,6 +46,7 @@ struct SettingsView: View {
                                 .foregroundColor(.contentPrimary)
                         }
                         .padding(.horizontal, geometry.size.width * 0.06)
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(PlainButtonStyle())
                     

--- a/Kabinett/Presentation/View/SignUp/LoginView.swift
+++ b/Kabinett/Presentation/View/SignUp/LoginView.swift
@@ -10,49 +10,54 @@ import AuthenticationServices
 
 struct LoginView: View {
     @StateObject private var viewModel = SignUpViewModel(signUpUseCase: SignUpUseCaseStub())
+    @State private var showAlert = false
     
     var body: some View {
         NavigationStack {
             VStack {
                 GeometryReader { geometry in
-                        VStack {
-                            Circle()
-                                .foregroundColor(.primary300)
-                                .frame(width: 110)
-                                .padding(.bottom, -1)
-                            Text("User")
-                                .fontWeight(.regular)
-                                .font(.system(size: 36))
-                                .padding(.bottom, 0.1)
-                            Text("000-000")
-                                .fontWeight(.light)
-                                .font(.system(size: 16))
-                                .monospaced()
-                                .padding(.bottom, 3)
-                            Text("비회원 계정이에요.")
-                                .fontWeight(.black)
-                                .font(.system(size: 16))
-                                .foregroundStyle(.contentSecondary)
-                                .padding(.bottom, 25)
-                            
-                            SignInWithAppleButton { request in
-                                viewModel.handleSignInWithAppleRequest(request)
-                            } onCompletion: { result in
-                                viewModel.handleAuthorization(result: result)
+                    VStack {
+                        Circle()
+                            .foregroundColor(.primary300)
+                            .frame(width: 110)
+                            .padding(.bottom, -1)
+                        Text("User")
+                            .fontWeight(.regular)
+                            .font(.system(size: 36))
+                            .padding(.bottom, 0.1)
+                        Text("000-000")
+                            .fontWeight(.light)
+                            .font(.system(size: 16))
+                            .monospaced()
+                            .padding(.bottom, 3)
+                        Text("비회원 계정이에요.")
+                            .fontWeight(.black)
+                            .font(.system(size: 16))
+                            .foregroundStyle(.contentSecondary)
+                            .padding(.bottom, 25)
+                        
+                        SignInWithAppleButton { request in
+                            viewModel.handleSignInWithAppleRequest(request)
+                        } onCompletion: { result in
+                            viewModel.handleAuthorization(result: result)
+                            if viewModel.loginError != nil {
+                                showAlert = true
                             }
-                            .padding(.horizontal, geometry.size.width * 0.06)
-                            .frame(height: 54)
-                            
-                            if let error = viewModel.loginError {
-                                Text(error)
-                                    .foregroundColor(.alert)
-                            }
+                        }
+                        .padding(.horizontal, geometry.size.width * 0.06)
+                        .frame(height: 54)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(Color.background)
                 }
                 .navigationDestination(isPresented: $viewModel.loginSuccess) {
                     SignUpNameInputView(viewModel: viewModel)
+                }
+                .alert(isPresented: $showAlert) {
+                    Alert(title: Text("오류"),
+                          message: Text(viewModel.loginError ?? "알 수 없는 로그인 오류가 발생했습니다."),
+                          dismissButton: .default(Text("확인"))
+                    )
                 }
             }
         }

--- a/Kabinett/Presentation/View/SignUp/LoginView.swift
+++ b/Kabinett/Presentation/View/SignUp/LoginView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import AuthenticationServices
 
 struct LoginView: View {
-    @StateObject private var viewModel = SignUpViewModel(useCase: SignUpUseCaseStub())
+    @StateObject private var viewModel = SignUpViewModel(signUpUseCase: SignUpUseCaseStub())
     
     var body: some View {
         NavigationStack {

--- a/Kabinett/Presentation/View/SignUp/LoginView.swift
+++ b/Kabinett/Presentation/View/SignUp/LoginView.swift
@@ -53,15 +53,23 @@ struct LoginView: View {
                 .navigationDestination(isPresented: $viewModel.loginSuccess) {
                     SignUpNameInputView(viewModel: viewModel)
                 }
-                .alert(isPresented: $showAlert) {
-                    Alert(title: Text("오류"),
-                          message: Text(viewModel.loginError ?? "알 수 없는 로그인 오류가 발생했습니다."),
-                          dismissButton: .default(Text("확인"))
-                    )
+                .alert(
+                    "오류",
+                    isPresented: $showAlert
+                ) {
+                    Button("확인", role: .cancel) {
+                    }
+                } message: {
+                    Text(viewModel.loginError ?? "알 수 없는 로그인 오류가 발생했습니다.")
                 }
             }
         }
     }
+}
+
+struct LoginErrorDetails: Identifiable {
+    let id = UUID()
+    let message: String
 }
 
 #Preview {

--- a/Kabinett/Presentation/View/SignUp/SignUpKabinettNumberSelectView.swift
+++ b/Kabinett/Presentation/View/SignUp/SignUpKabinettNumberSelectView.swift
@@ -100,8 +100,14 @@ struct SignUpKabinettNumberSelectView: View {
                     }
                     .disabled(viewModel.selectedKabinettNumber == nil)
                     .padding(.horizontal, geometry.size.width * 0.06)
-                    .alert(isPresented: $showAlert) {
-                        Alert(title: Text("오류"), message: Text(alertMessage), dismissButton: .default(Text("확인")))
+                    .alert(
+                        "오류",
+                        isPresented: $showAlert
+                    ) {
+                        Button("확인", role: .cancel) {
+                        }
+                    } message: {
+                        Text(alertMessage)
                     }
 
                     .navigationDestination(isPresented:$shouldNavigatedToProfile) {

--- a/Kabinett/Presentation/View/SignUp/SignUpKabinettNumberSelectView.swift
+++ b/Kabinett/Presentation/View/SignUp/SignUpKabinettNumberSelectView.swift
@@ -112,8 +112,7 @@ struct SignUpKabinettNumberSelectView: View {
 
                     .navigationDestination(isPresented:$shouldNavigatedToProfile) {
                         ProfileView(
-                            viewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()),
-                            shouldHideBackButton: true
+                            viewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub())
                         )
                     }
                     .navigationBarBackButtonHidden(true)

--- a/Kabinett/Presentation/View/SignUp/SignUpKabinettNumberSelectView.swift
+++ b/Kabinett/Presentation/View/SignUp/SignUpKabinettNumberSelectView.swift
@@ -112,7 +112,7 @@ struct SignUpKabinettNumberSelectView: View {
 
                     .navigationDestination(isPresented:$shouldNavigatedToProfile) {
                         ProfileView(
-                            viewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub())
+                            profileViewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub())
                         )
                     }
                     .navigationBarBackButtonHidden(true)

--- a/Kabinett/Presentation/View/SignUp/SignUpKabinettNumberSelectView.swift
+++ b/Kabinett/Presentation/View/SignUp/SignUpKabinettNumberSelectView.swift
@@ -84,9 +84,8 @@ struct SignUpKabinettNumberSelectView: View {
                                 if success {
                                     shouldNavigatedToProfile = true
                                 } else {
-                                    alertMessage = "로그인에 실패했습니다."
+                                    alertMessage = "회원가입에 실패했습니다."
                                     showAlert = true
-                                    print("Login failed")
                                 }
                             }
                         }

--- a/Kabinett/Presentation/View/SignUp/SignUpNameInputView.swift
+++ b/Kabinett/Presentation/View/SignUp/SignUpNameInputView.swift
@@ -91,5 +91,5 @@ struct SignUpOvalTextFieldStyle: TextFieldStyle {
 }
 
 #Preview {
-    SignUpNameInputView(viewModel: SignUpViewModel(useCase: SignUpUseCaseStub()))
+    SignUpNameInputView(viewModel: SignUpViewModel(signUpUseCase: SignUpUseCaseStub()))
 }

--- a/Kabinett/Presentation/ViewModel/LetterWrite/UserSelectionViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/LetterWrite/UserSelectionViewModel.swift
@@ -15,13 +15,13 @@ class UserSelectionViewModel: ObservableObject {
     @Published var fromUser: Writer? = nil
     @Published var toUser: Writer? = nil
     @Published var dummyUsers: [Writer] = [
-        Writer(id: "user_1", name: "Alice", kabinettNumber: 111111, profileImage: "https://cdn.pixabay.com/photo/2022/06/25/13/33/landscape-7283516_1280.jpg"),
-        Writer(id: "user_2", name: "Bob", kabinettNumber: 234234, profileImage: nil),
-        Writer(id: "user_3", name: "Charlie", kabinettNumber: 1112, profileImage: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTpxjfCS04oKkgLWiCPCQg026DciIS5ayfvTg&s"),
-        Writer(id: "user_4", name: "David", kabinettNumber: 11131, profileImage: nil),
-        Writer(id: "user_5", name: "Eve", kabinettNumber: 114141, profileImage: nil),
-        Writer(id: "user_6", name: "Frank", kabinettNumber: 1151, profileImage: nil),
-        Writer(id: "user_7", name: "Grace", kabinettNumber: 111161, profileImage: nil),
+        Writer(name: "Alice", kabinettNumber: 111111, profileImage: "https://cdn.pixabay.com/photo/2022/06/25/13/33/landscape-7283516_1280.jpg"),
+        Writer(name: "Bob", kabinettNumber: 234234, profileImage: nil),
+        Writer(name: "Charlie", kabinettNumber: 1112, profileImage: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTpxjfCS04oKkgLWiCPCQg026DciIS5ayfvTg&s"),
+        Writer(name: "David", kabinettNumber: 11131, profileImage: nil),
+        Writer(name: "Eve", kabinettNumber: 114141, profileImage: nil),
+        Writer(name: "Frank", kabinettNumber: 1151, profileImage: nil),
+        Writer(name: "Grace", kabinettNumber: 111161, profileImage: nil),
     ]
     
     init() {
@@ -32,7 +32,7 @@ class UserSelectionViewModel: ObservableObject {
     private func updateFromUser() {
         if let user = dummyUsers.first(where: { $0.kabinettNumber == userKabi }) {
             checkLogin = true
-            fromUser = Writer(id: user.id, name: user.name, kabinettNumber: user.kabinettNumber, profileImage: user.profileImage)
+            fromUser = Writer(name: user.name, kabinettNumber: user.kabinettNumber, profileImage: user.profileImage)
         } else {
             checkLogin = false
             fromUser = Writer(name: "나", kabinettNumber: 0, profileImage: nil)
@@ -42,7 +42,7 @@ class UserSelectionViewModel: ObservableObject {
     
     func updateToUser(_ letterContent: inout LetterWriteViewModel, toUserName: String) {
         if let user = dummyUsers.first(where: { $0.name == toUserName }) {
-            toUser = Writer(id: user.id, name: user.name, kabinettNumber: user.kabinettNumber, profileImage: user.profileImage)
+            toUser = Writer(name: user.name, kabinettNumber: user.kabinettNumber, profileImage: user.profileImage)
             letterContent.toUserId = toUser?.id
             letterContent.toUserName = toUser?.name ?? ""
             letterContent.toUserKabinettNumber = toUser?.kabinettNumber

--- a/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
@@ -10,11 +10,13 @@ import Combine
 import PhotosUI
 
 class ProfileSettingsViewModel: ObservableObject {
-    @Published var userName: String
+    private let profileUseCase: ProfileUseCase
+    
+    @Published var userName: String = ""
     @Published var newUserName: String = ""
     @Published var profileImage: UIImage?
-    @Published var kabinettNumber: String
-    @Published var appleID: String
+    @Published var formattedKabinettNumber: String = ""
+    @Published var appleID: String = "figfigure33@gmail.com"
     @Published var shouldNavigateToSettings = false
     @Published var selectedImageItem: PhotosPickerItem?
     @Published var selectedImage: UIImage?
@@ -23,15 +25,32 @@ class ProfileSettingsViewModel: ObservableObject {
     @Published var croppedImage: UIImage?
     @Published var isProfileUpdated = false
     
-    init(userName: String = "Yule",
-         profileImage: UIImage? = nil,
-         kabinettNumber: String = "455-544",
-         appleID: String = "figfigure33@gmail.com",
-         selectedImageItem: PhotosPickerItem? = nil) {
-        self.userName = userName
-        self.profileImage = profileImage
-        self.kabinettNumber = kabinettNumber
-        self.appleID = appleID
+    init(profileUseCase: ProfileUseCase) {
+        self.profileUseCase = profileUseCase
+        
+        Task {
+            await loadInitialData()
+        }
+    }
+    
+    private func loadInitialData() async {
+        let writer = await profileUseCase.getCurrentWriter()
+        DispatchQueue.main.async {
+            self.userName = writer.name
+            self.formattedKabinettNumber = self.formatKabinettNumber(writer.kabinettNumber)
+            if let imageUrlString = writer.profileImage, // 이미지 url로 저장하는지? 유즈케이스랑 라이터랑 타입이 다름
+               let imageUrl = URL(string: imageUrlString),
+               let imageData = try? Data(contentsOf: imageUrl),
+               let image = UIImage(data: imageData) {
+                self.profileImage = image
+            } else {
+                self.profileImage = nil
+            }
+        }
+    } // 프로필 이미지 없을 때 탭바 이미지도 설정하기
+    
+    private func formatKabinettNumber(_ number: Int) -> String {
+        return String(format: "%03d-%03d", number / 1000, number % 1000)
     }
     
     var isUserNameVaild: Bool {
@@ -66,5 +85,27 @@ class ProfileSettingsViewModel: ObservableObject {
         updateUserName()
         updateProfileImage()
         objectWillChange.send()
+    }
+    
+    func crop(image: UIImage, cropArea: CGRect, imageViewSize: CGSize) {
+        let scaleX = image.size.width / imageViewSize.width * image.scale
+        let scaleY = image.size.height / imageViewSize.height * image.scale
+        let scaledCropArea = CGRect(
+            x: cropArea.origin.x * scaleX,
+            y: cropArea.origin.y * scaleY,
+            width: cropArea.size.width * scaleX,
+            height: cropArea.size.height * scaleY
+        )
+        
+        guard let cutImageRef: CGImage =
+                image.cgImage?.cropping(to: scaledCropArea) else {
+            return
+        }
+        
+        let croppedImage = UIImage(cgImage: cutImageRef)
+        DispatchQueue.main.async {
+            self.croppedImage = croppedImage
+            self.isShowingCropper = false
+        }
     }
 }

--- a/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
@@ -15,7 +15,7 @@ class ProfileSettingsViewModel: ObservableObject {
     @Published var userName: String = ""
     @Published var newUserName: String = ""
     @Published var formattedKabinettNumber: String = ""
-    @Published var appleID: String = "figfigure33@gmail.com" //추후 유즈케이스에 추가
+    @Published var appleID: String = ""
     @Published var profileImage: UIImage?
     @Published var isShowingImagePicker = false
     @Published var selectedImageItem: PhotosPickerItem?
@@ -30,6 +30,7 @@ class ProfileSettingsViewModel: ObservableObject {
         
         Task {
             await loadInitialData()
+            await fetchAppleID()
         }
     }
     
@@ -48,6 +49,11 @@ class ProfileSettingsViewModel: ObservableObject {
             }
         }
     } // 프로필 이미지 없을 때 탭바 이미지도 설정하기
+    
+    private func fetchAppleID() async {
+        let ID = await profileUseCase.getAppleID()
+        self.appleID = ID
+    }
     
     var isUserNameVaild: Bool {
         return !newUserName.isEmpty

--- a/Kabinett/Presentation/ViewModel/Profile/SignUpViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/Profile/SignUpViewModel.swift
@@ -54,22 +54,13 @@ final class SignUpViewModel: ObservableObject {
         switch result {
         case .success(let authorization):
             Task { @MainActor in
-                let sucess = await useCase.signUp(authorization)
-                await MainActor.run {
-//                    if sucess {
-//                        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-//                            let userIdentifier = appleIDCredential.user
-//                            let userEmail = appleIDCredential.email ?? "이메일 정보 없음"
-//                            self.loginSuccess = true
-//                            self.loginError = nil
-//                            print("사용자 ID: \(userIdentifier)")
-//                            print("이메일: \(userEmail)")
-//                            print("로그인 성공")
-//                        }
-//                    } else {
-//                        self.loginError = "로그인에 실패했습니다."
-//                        print("로그인 실패")
-//                    }
+                let success = await useCase.signUp(authorization)
+                if success {
+                    print("Sign up successed")
+                    self.loginSuccess = true
+                } else {
+                    print("Sign up failed")
+                    self.loginError = "Sign up failed"
                 }
             }
         case .failure(let error):

--- a/Kabinett/Presentation/ViewModel/SignUp/KabinettNumberFormatter.swift
+++ b/Kabinett/Presentation/ViewModel/SignUp/KabinettNumberFormatter.swift
@@ -1,0 +1,12 @@
+//
+//  KabinettNumberFormatter.swift
+//  Kabinett
+//
+//  Created by Yule on 8/28/24.
+//
+
+import Foundation
+
+func formatKabinettNumber(_ number: Int) -> String {
+    return String(format: "%03d-%03d", number / 1000, number % 1000)
+}

--- a/Kabinett/Presentation/ViewModel/SignUp/SignUpViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/SignUp/SignUpViewModel.swift
@@ -18,7 +18,6 @@ final class SignUpViewModel: ObservableObject {
     @Published var selectedKabinettNumber: Int? = nil
     @Published var currentNonce: String?
     @Published var userIdentifier: String?
-    @Published var userEmail: String?
     @Published var loginError: String?
     @Published var loginSuccess: Bool = false
     
@@ -41,16 +40,8 @@ final class SignUpViewModel: ObservableObject {
         let numbers = await signUpUseCase.getAvailableKabinettNumbers()
         availablekabinettNumbers = numbers
             .map {
-                formatNumber($0)
+                formatKabinettNumber($0)
             }
-    }
-    private func formatNumber(_ number: Int) -> String {
-        let formattedNumber = String(format: "%06d", number)
-        let startIndex = formattedNumber.index(formattedNumber.startIndex, offsetBy: 3)
-        let part1 = formattedNumber[..<startIndex]
-        let part2 = formattedNumber[startIndex...]
-        
-        return "\(part1)-\(part2)"
     }
     
     func handleSignInWithAppleRequest(_ request: ASAuthorizationAppleIDRequest) {
@@ -70,11 +61,11 @@ final class SignUpViewModel: ObservableObject {
                     self.loginSuccess = true
                 } else {
                     print("Sign up failed")
-                    self.loginError = "Sign up failed"
+                    self.loginError = "로그인에 실패했습니다."
                 }
             }
         case .failure(let error):
-            print("Authorization failed: \(error.localizedDescription)")
+            print("애플 로그인에 실패했습니다: \(error.localizedDescription)")
         }
     }
     


### PR DESCRIPTION
### 📕 Issue Number

Close #62 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] SignUpUsecase 가짜 객체와 SignUpViewModel 연결하기
- [x] 가짜객체에 따른 회원가입 결과 화면 분기처리
- [x] 지난 PR에 있었던 warning들 제거


### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

![SignUp2Profile_S](https://github.com/user-attachments/assets/4e2dfb79-d064-4994-9ff9-78cb25c4e855)
<회원가입 성공 화면>
입력한 내용이 프로필에 안나오는 것은 가짜객체로 각 값을 넣어주어서 그래요~
![SignUp2Profile_F](https://github.com/user-attachments/assets/3d421e2a-3ee2-405b-9a03-b018448cffbc)
<회원가입 실패 화면>

- 프린트문이 이후 작업에서 필요해서 한꺼번에 지울게요~

<br/><br/>