### PR TITLE
Feature/login and profile_프로필탭 화면 분기

### DIFF
--- a/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
+++ b/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
@@ -29,6 +29,9 @@ protocol ProfileUseCase {
 final class ProfileUseCaseStub: ProfileUseCase {
     func getCurrentUserStatus() async -> AnyPublisher<UserStatus, Never> {
         Just(.anonymous)
+//        Just(.incomplete)
+//        Just(.registered)
+        
             .eraseToAnyPublisher()
     }
     func getCurrentWriter() async -> Writer {

--- a/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
+++ b/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
@@ -8,8 +8,14 @@
 import Foundation
 import Combine
 
+enum UserStatus {
+    case anonymous
+    case registered
+    case incomplete
+}
+
 protocol ProfileUseCase {
-    func isAnonymous() async -> AnyPublisher<Bool, Never>
+    func getCurrentUserStatus() async -> AnyPublisher<UserStatus, Never>
     func getCurrentWriter() async -> Writer
     func getAppleID() async -> String
     func updateWriter(
@@ -21,8 +27,8 @@ protocol ProfileUseCase {
 }
 
 final class ProfileUseCaseStub: ProfileUseCase {
-    func isAnonymous() async -> AnyPublisher<Bool, Never> {
-        Just(false)
+    func getCurrentUserStatus() async -> AnyPublisher<UserStatus, Never> {
+        Just(.anonymous)
             .eraseToAnyPublisher()
     }
     func getCurrentWriter() async -> Writer {

--- a/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
+++ b/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
@@ -37,8 +37,6 @@ final class SignUpUseCaseStub: SignupUseCase {
     }
     
     func startLoginUser(with userName: String, kabinettNumber: Int) async -> Bool {
-        print("Received userName in UseCase: \(userName)")
-        print("Received Kabinett Number in UseCase: \(kabinettNumber)")
         return true
     }
 }

--- a/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
+++ b/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
@@ -10,7 +10,7 @@ import AuthenticationServices
 
 enum SignUpResult {
     case newUser
-    case alreadyRegistered
+    case registered
     case signInOnly
 }
 
@@ -32,7 +32,7 @@ final class SignUpUseCaseStub: SignupUseCase {
     
     func signUp(_ authorization: ASAuthorization) async -> SignUpResult {
         .newUser
-//        .alreadyRegistered
+//        .registered
 //        .signInOnly
     }
     

--- a/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
@@ -40,9 +40,11 @@ struct ProfileSettingsView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: {
-                        viewModel.completeProfileUpdate()
-                        shouldNavigateToProfileView = true
-                        dismiss()
+                        Task {
+                            await viewModel.completeProfileUpdate()
+                            shouldNavigateToProfileView = true
+                            dismiss()
+                        }
                     }) {
                         Text("완료")
                             .fontWeight(.medium)

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -68,10 +68,8 @@ struct ProfileView: View {
                 .navigationBarBackButtonHidden()
             }
         }
-        .onAppear {
-            Task {
-                await profileViewModel.checkUserStatus()
-            }
+        .task {
+            await profileViewModel.checkUserStatus()
         }
     }
 }

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -62,8 +62,6 @@ struct ProfileView: View {
         .onAppear {
             Task {
                 await profileViewModel.checkUserStatus()
-                print("User status after check: \(profileViewModel.userStatus))")
-                print("Should navigate to login: \(profileViewModel.shouldNavigateToLogin)")
             }
         }
     }

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -8,53 +8,67 @@
 import SwiftUI
 
 struct ProfileView: View {
-    @StateObject var profileViewModel: ProfileSettingsViewModel
+    @StateObject var profileViewModel = ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub())
     
     var body: some View {
         GeometryReader { geometry in
             NavigationStack {
-                VStack{
-                    if let image = profileViewModel.profileImage {
-                        Image(uiImage: image)
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width:110, height: 110)
-                            .clipShape(Circle())
-                            .padding(.bottom, -1)
+                Group {
+                    if profileViewModel.shouldNavigateToLogin {
+                        LoginView()
                     } else {
-                        Circle()
-                            .foregroundColor(.primary300)
-                            .frame(width: 110, height: 110)
-                            .padding(.bottom, -1)
-                    }
-                    
-                    Text(profileViewModel.userName)
-                        .fontWeight(.regular)
-                        .font(.system(size: 36))
-                        .padding(.bottom, 0.1)
-                    Text(profileViewModel.formattedKabinettNumber)
-                        .fontWeight(.light)
-                        .font(.system(size: 16))
-                        .monospaced()
-                }
-                .padding(.horizontal, geometry.size.width * 0.06)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.background)
-                .navigationBarBackButtonHidden()
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        NavigationLink(destination: SettingsView(profileViewModel: profileViewModel)) {
-                            Image(systemName: "gearshape")
-                                .fontWeight(.medium)
-                                .font(.system(size: 19))
-                                .foregroundColor(.contentPrimary)
+                        VStack {
+                            if let image = profileViewModel.profileImage {
+                                Image(uiImage: image)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width:110, height: 110)
+                                    .clipShape(Circle())
+                                    .padding(.bottom, -1)
+                            } else {
+                                Circle()
+                                    .foregroundColor(.primary300)
+                                    .frame(width: 110, height: 110)
+                                    .padding(.bottom, -1)
+                            }
+                            
+                            Text(profileViewModel.userName)
+                                .fontWeight(.regular)
+                                .font(.system(size: 36))
+                                .padding(.bottom, 0.1)
+                            Text(profileViewModel.formattedKabinettNumber)
+                                .fontWeight(.light)
+                                .font(.system(size: 16))
+                                .monospaced()
+                        }
+                        .padding(.horizontal, geometry.size.width * 0.06)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(Color.background)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarTrailing) {
+                                NavigationLink(destination: SettingsView(profileViewModel: profileViewModel)) {
+                                    Image(systemName: "gearshape")
+                                        .fontWeight(.medium)
+                                        .font(.system(size: 19))
+                                        .foregroundColor(.contentPrimary)
+                                }
+                            }
                         }
                     }
                 }
+                .navigationBarBackButtonHidden()
+            }
+        }
+        .onAppear {
+            Task {
+                await profileViewModel.checkUserStatus()
+                print("User status after check: \(profileViewModel.userStatus))")
+                print("Should navigate to login: \(profileViewModel.shouldNavigateToLogin)")
             }
         }
     }
 }
+
 #Preview {
     ProfileView(profileViewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
 }

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -44,6 +44,15 @@ struct ProfileView: View {
                         .padding(.horizontal, geometry.size.width * 0.06)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .background(Color.background)
+                        .alert(
+                            "오류",
+                            isPresented: $profileViewModel.showProfileAlert
+                        ) {
+                            Button("확인", role: .cancel) {
+                            }
+                        } message: {
+                            Text(profileViewModel.profileUpdateError ?? "알 수 없는 프로필 업데이트 오류가 발생했어요.")
+                        }
                         .toolbar {
                             ToolbarItem(placement: .navigationBarTrailing) {
                                 NavigationLink(destination: SettingsView(profileViewModel: profileViewModel)) {

--- a/Kabinett/Presentation/View/SignUp/SignUpKabinettNumberSelectView.swift
+++ b/Kabinett/Presentation/View/SignUp/SignUpKabinettNumberSelectView.swift
@@ -73,9 +73,6 @@ struct SignUpKabinettNumberSelectView: View {
                             if let selectedIndex = signUpViewModel.selectedKabinettNumber {
                                 let selectedKabinettNumber = signUpViewModel.availablekabinettNumbers[selectedIndex]
                                 
-                                print("UserName: \(signUpViewModel.userName)")
-                                print("Selected Kabinett Number: \(selectedKabinettNumber)")
-                                
                                 let success = await signUpViewModel.startLoginUser(
                                     with: signUpViewModel.userName,
                                     kabinettNumber: selectedKabinettNumber

--- a/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
@@ -61,13 +61,10 @@ class ProfileSettingsViewModel: ObservableObject {
                 self?.userStatus = status
                 switch status {
                 case .anonymous:
-                    print("User status is anonymous")
                     self?.shouldNavigateToLogin = true
                 case .incomplete:
-                    print("User status is incomplete")
                     self?.shouldNavigateToLogin = true
                 case .registered:
-                    print("User status is registered")
                     self?.shouldNavigateToProfile = true
                 }
             }
@@ -99,9 +96,7 @@ class ProfileSettingsViewModel: ObservableObject {
         if let croppedImage = croppedImage {
             self.profileImage = croppedImage
             isProfileUpdated = true
-            print("Profile image updated in ViewModel. New image size: \(croppedImage.size)")
         } else {
-            print("No image to update")
         }
     }
     

--- a/Kabinett/Presentation/ViewModel/SignUp/SignUpViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/SignUp/SignUpViewModel.swift
@@ -64,7 +64,7 @@ final class SignUpViewModel: ObservableObject {
                 case .newUser:
                     print("Sign up State: New User")
                     self.loginSuccess = true
-                case .alreadyRegistered:
+                case .registered:
                     self.profileViewModel = ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()) //프로필 뷰 오류 테스트하려면 여기 주석처리
                     print("Sign up State: Already Registered")
                     self.signUpSuccess = true

--- a/Kabinett/Presentation/ViewModel/SignUp/SignUpViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/SignUp/SignUpViewModel.swift
@@ -69,7 +69,7 @@ final class SignUpViewModel: ObservableObject {
                     self.loginSuccess = true
                 }
             }
-        case .failure(let error):
+        case .failure(_):
             self.loginError = "애플 로그인에 실패했어요."
             self.showAlert = true
         }

--- a/Kabinett/Presentation/ViewModel/SignUp/SignUpViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/SignUp/SignUpViewModel.swift
@@ -32,7 +32,6 @@ final class SignUpViewModel: ObservableObject {
     @MainActor
        func startLoginUser(with userName: String, kabinettNumber: String) async -> Bool {
            guard let kabinettNumberInt = Int(kabinettNumber.replacingOccurrences(of: "-", with: "")) else {
-               print("Invalid Kabinett number format")
                return false
            }
            
@@ -62,19 +61,15 @@ final class SignUpViewModel: ObservableObject {
                 let signUpResult = await signUpUseCase.signUp(authorization)
                 switch signUpResult {
                 case .newUser:
-                    print("Sign up State: New User")
                     self.loginSuccess = true
                 case .registered:
                     self.profileViewModel = ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()) //프로필 뷰 오류 테스트하려면 여기 주석처리
-                    print("Sign up State: Already Registered")
                     self.signUpSuccess = true
                 case .signInOnly:
-                    print("Sign up State: Apple SignIn Only")
                     self.loginSuccess = true
                 }
             }
         case .failure(let error):
-            print("애플 로그인 실패: \(error.localizedDescription)")
             self.loginError = "애플 로그인에 실패했어요."
             self.showAlert = true
         }


### PR DESCRIPTION
### 📕 Issue Number

Close #79 


### 📙 작업 내역

> 유저가 새로운 유저라면 프로필 탭을 눌렀을 때 로그인 화면을 띄워주고, 이미 로그인한 유저라면 프로필 화면을 띄워줘요.

- [x] getCurrentUserStatus() ProfileSettingsViewModel에 주입
- [x] ProfileView에서 유저 상태에 따른 화면 분기 로직

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x]코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

| ![NewUser](https://github.com/user-attachments/assets/7e710370-d6fb-4340-bc1c-9d4416d73d8f) | ![Registered](https://github.com/user-attachments/assets/152b9e31-f323-4cdb-a223-8570481acabd) |
|:--------------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------:|
| 새로운 유저, 로그인만 마치고 회원가입 중 이탈한 유저                                                                                     | 등록 유저                                                                                     |


<br/><br/>