### PR TITLE
Feature/logout and account deletion

### DIFF
--- a/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
+++ b/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
@@ -28,9 +28,9 @@ protocol ProfileUseCase {
 
 final class ProfileUseCaseStub: ProfileUseCase {
     func getCurrentUserStatus() async -> AnyPublisher<UserStatus, Never> {
-        Just(.anonymous)
+//        Just(.anonymous)
 //        Just(.incomplete)
-//        Just(.registered)
+        Just(.registered)
         
             .eraseToAnyPublisher()
     }
@@ -48,9 +48,11 @@ final class ProfileUseCaseStub: ProfileUseCase {
     func updateWriter(newWriterName: String, profileImage: Data?) async -> Bool {
         true
     }
+    
     func signout() async -> Bool {
         false
     }
+    
     func deleteId() async -> Bool {
         false
     }

--- a/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
+++ b/Kabinett/Domain/UseCase/ProfileUseCase/ProfileUseCase.swift
@@ -50,10 +50,10 @@ final class ProfileUseCaseStub: ProfileUseCase {
     }
     
     func signout() async -> Bool {
-        false
+        true
     }
     
     func deleteId() async -> Bool {
-        false
+        true
     }
 }

--- a/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
+++ b/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
@@ -31,8 +31,8 @@ final class SignUpUseCaseStub: SignupUseCase {
     }
     
     func signUp(_ authorization: ASAuthorization) async -> SignUpResult {
-        .newUser
-//        .registered
+//        .newUser
+        .registered
 //        .signInOnly
     }
     

--- a/Kabinett/Presentation/View/Profile/AccountSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/AccountSettingsView.swift
@@ -8,14 +8,17 @@
 import SwiftUI
 
 struct AccountSettingsView: View {
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
+    @State private var showLogoutAlert = false
+    @State private var showAccountDeletionAlert = false
+    @ObservedObject var profileViewModel: ProfileSettingsViewModel
     
     var body: some View {
         NavigationStack {
             GeometryReader { geometry in
                 VStack {
                     Button(action: {
-                        print("로그아웃")
+                        showLogoutAlert = true
                     }) {
                         HStack{
                             Text("로그아웃하기")
@@ -31,31 +34,54 @@ struct AccountSettingsView: View {
                         .padding(.horizontal, geometry.size.width * 0.06)
                         .contentShape(Rectangle())
                     }
-                    .buttonStyle(PlainButtonStyle())
-                    
-                    Spacer()
-                    
-                    Button(action: {
-                        print("회원탈퇴")
-                    }) {
-                        VStack {
-                            Text("회원 탈퇴하기")
-                                .foregroundColor(.alert)
-                                .padding(.bottom, 5)
-                            Text("저장된 데이터가 모두 사라집니다.")
-                                .font(.system(size: 12))
-                                .foregroundColor(.contentSecondary)
+                    .alert(
+                        "로그아웃하시겠어요?",
+                        isPresented: $showLogoutAlert
+                    ) {
+                        Button("로그아웃", role: .destructive) {
+                            Task {
+                                await profileViewModel.signout()
+                            }
                         }
-                        .padding(.horizontal, geometry.size.width * 0.06)
-                        .contentShape(Rectangle())
+                        Button("취소", role: .cancel) {}
                     }
-                    .buttonStyle(PlainButtonStyle())
-                }
+                    
+                        Spacer()
+                        
+                        Button(action: {
+                            showAccountDeletionAlert = true
+                        }) {
+                            VStack {
+                                Text("회원 탈퇴하기")
+                                    .foregroundColor(.alert)
+                                    .padding(.bottom, 3)
+                                Text("저장된 데이터가 모두 사라져요.")
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.contentSecondary)
+                                    .padding(.bottom, 20)
+                            }
+                            .padding(.horizontal, geometry.size.width * 0.06)
+                            .contentShape(Rectangle())
+                        }
+                        .alert(
+                            "회원 탈퇴하시겠어요?",
+                            isPresented: $showAccountDeletionAlert
+                        ) {
+                            Button("회원탈퇴", role: .destructive) {
+                                Task {
+                                    await profileViewModel.deletieID()
+                                }
+                            }
+                            Button("취소", role: .cancel) {}
+                        } message: {
+                            Text("저장된 데이터가 모두 사라져요.")
+                        }
+                    }
                 .navigationBarBackButtonHidden(true)
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button(action: {
-                            presentationMode.wrappedValue.dismiss()
+                            dismiss()
                         }) {
                             HStack {
                                 Image(systemName: "chevron.left")
@@ -74,6 +100,6 @@ struct AccountSettingsView: View {
     }
 }
 
-#Preview {
-    AccountSettingsView()
-}
+//#Preview {
+//    AccountSettingsView()
+//}

--- a/Kabinett/Presentation/View/Profile/AccountSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/AccountSettingsView.swift
@@ -12,6 +12,7 @@ struct AccountSettingsView: View {
     @State private var showLogoutAlert = false
     @State private var showAccountDeletionAlert = false
     @ObservedObject var profileViewModel: ProfileSettingsViewModel
+    var onComplete: () -> Void
     
     var body: some View {
         NavigationStack {
@@ -41,6 +42,7 @@ struct AccountSettingsView: View {
                         Button("로그아웃", role: .destructive) {
                             Task {
                                 await profileViewModel.signout()
+                                onComplete()
                             }
                         }
                         Button("취소", role: .cancel) {}
@@ -70,6 +72,7 @@ struct AccountSettingsView: View {
                             Button("회원탈퇴", role: .destructive) {
                                 Task {
                                     await profileViewModel.deletieID()
+                                    onComplete()
                                 }
                             }
                             Button("취소", role: .cancel) {}

--- a/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
@@ -12,6 +12,7 @@ struct ProfileSettingsView: View {
     @ObservedObject var viewModel: ProfileSettingsViewModel
     @Environment(\.dismiss) var dismiss
     @Binding var shouldNavigateToProfileView: Bool
+    var onComplete: () -> Void
     
     var body: some View {
         NavigationStack {
@@ -42,7 +43,7 @@ struct ProfileSettingsView: View {
                     Button(action: {
                         Task {
                             await viewModel.completeProfileUpdate()
-                            shouldNavigateToProfileView = true
+                            onComplete()
                             dismiss()
                         }
                     }) {

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -8,59 +8,57 @@
 import SwiftUI
 
 struct ProfileView: View {
-    @StateObject var profileViewModel = ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub())
+    @ObservedObject var profileViewModel = ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub())
     
     var body: some View {
-        GeometryReader { geometry in
-            NavigationStack {
-                Group {
-                    if profileViewModel.shouldNavigateToLogin {
-                        LoginView()
-                    } else {
-                        VStack {
-                            if let image = profileViewModel.profileImage {
-                                Image(uiImage: image)
-                                    .resizable()
-                                    .scaledToFill()
-                                    .frame(width:110, height: 110)
-                                    .clipShape(Circle())
-                                    .padding(.bottom, -1)
-                            } else {
-                                Circle()
-                                    .foregroundColor(.primary300)
-                                    .frame(width: 110, height: 110)
-                                    .padding(.bottom, -1)
-                            }
-                            
-                            Text(profileViewModel.userName)
-                                .fontWeight(.regular)
-                                .font(.system(size: 36))
-                                .padding(.bottom, 0.1)
-                            Text(profileViewModel.formattedKabinettNumber)
-                                .fontWeight(.light)
-                                .font(.system(size: 16))
-                                .monospaced()
+        NavigationStack {
+            if profileViewModel.shouldNavigateToLogin || profileViewModel.isLoggedOut || profileViewModel.isDeletedAccount {
+                LoginView()
+            } else {
+                GeometryReader { geometry in
+                    VStack {
+                        if let image = profileViewModel.profileImage {
+                            Image(uiImage: image)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width:110, height: 110)
+                                .clipShape(Circle())
+                                .padding(.bottom, -1)
+                        } else {
+                            Circle()
+                                .foregroundColor(.primary300)
+                                .frame(width: 110, height: 110)
+                                .padding(.bottom, -1)
                         }
-                        .padding(.horizontal, geometry.size.width * 0.06)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(Color.background)
-                        .alert(
-                            "오류",
-                            isPresented: $profileViewModel.showProfileAlert
-                        ) {
-                            Button("확인", role: .cancel) {
-                            }
-                        } message: {
-                            Text(profileViewModel.profileUpdateError ?? "알 수 없는 프로필 업데이트 오류가 발생했어요.")
+                        
+                        Text(profileViewModel.userName)
+                            .fontWeight(.regular)
+                            .font(.system(size: 36))
+                            .padding(.bottom, 0.1)
+                        Text(profileViewModel.formattedKabinettNumber)
+                            .fontWeight(.light)
+                            .font(.system(size: 16))
+                            .monospaced()
+                    }
+                    .padding(.horizontal, geometry.size.width * 0.06)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.background)
+                    .alert(
+                        "오류",
+                        isPresented: $profileViewModel.showProfileAlert
+                    ) {
+                        Button("확인", role: .cancel) {
                         }
-                        .toolbar {
-                            ToolbarItem(placement: .navigationBarTrailing) {
-                                NavigationLink(destination: SettingsView(profileViewModel: profileViewModel)) {
-                                    Image(systemName: "gearshape")
-                                        .fontWeight(.medium)
-                                        .font(.system(size: 19))
-                                        .foregroundColor(.contentPrimary)
-                                }
+                    } message: {
+                        Text(profileViewModel.profileUpdateError ?? "알 수 없는 프로필 업데이트 오류가 발생했어요.")
+                    }
+                    .toolbar {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            NavigationLink(destination: SettingsView(profileViewModel: profileViewModel)) {
+                                Image(systemName: "gearshape")
+                                    .fontWeight(.medium)
+                                    .font(.system(size: 19))
+                                    .foregroundColor(.contentPrimary)
                             }
                         }
                     }
@@ -71,6 +69,14 @@ struct ProfileView: View {
         .task {
             await profileViewModel.checkUserStatus()
         }
+        
+        .onChange(of: profileViewModel.isLoggedOut) { _ in
+            Task {
+                await profileViewModel.checkUserStatus()
+            }
+        }
+       
+        
     }
 }
 

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct ProfileView: View {
     @ObservedObject var profileViewModel = ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub())
     @State private var showSettingsView = false
-    @State private var shouldNavigateToLogin = false
     @State private var shouldNavigateToProfileView = false
     
     var body: some View {
@@ -79,25 +78,12 @@ struct ProfileView: View {
             }
         }
         .task {
-            await checkUserStatus()
-        }
-        .onChange(of: shouldNavigateToProfileView) { _, newValue in
-            if newValue {
-                shouldNavigateToProfileView = false
-            }
+            await profileViewModel.checkUserStatus()
         }
     }
     
     func handleAccountActionComplete() {
         showSettingsView = false
-        Task {
-            await checkUserStatus()
-        }
-    }
-    
-    func checkUserStatus() async {
-        await profileViewModel.checkUserStatus()
-        shouldNavigateToLogin = profileViewModel.shouldNavigateToLogin
     }
 }
 

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -81,6 +81,11 @@ struct ProfileView: View {
         .task {
             await checkUserStatus()
         }
+        .onChange(of: shouldNavigateToProfileView) { _, newValue in
+            if newValue {
+                shouldNavigateToProfileView = false
+            }
+        }
     }
     
     func handleAccountActionComplete() {

--- a/Kabinett/Presentation/View/Profile/SettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/SettingsView.swift
@@ -61,6 +61,7 @@ struct SettingsView: View {
                     }
                     .buttonStyle(PlainButtonStyle())
                     
+                    // TODO: - 추후에 다른 소셜로그인 추가되면 이미지 변경 가능하게 수정하기
                     HStack{
                         ZStack {
                             Rectangle()
@@ -69,7 +70,7 @@ struct SettingsView: View {
                             Image(systemName: "apple.logo")
                                 .font(.system(size: 14))
                                 .foregroundColor(.white)
-                        } //추후에 다른 소셜로그인 추가되면 이미지 변경 가능하게 수정하기
+                        }
                         .padding(.leading, 10)
                         Text(profileViewModel.appleID)
                             .font(.system(size: 17))

--- a/Kabinett/Presentation/View/Profile/SettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/SettingsView.swift
@@ -17,7 +17,14 @@ struct SettingsView: View {
         GeometryReader { geometry in
             NavigationStack {
                 VStack(alignment: .leading) {
-                    NavigationLink(destination: ProfileSettingsView(viewModel: profileViewModel,shouldNavigateToProfileView: $shouldNavigateToProfileView)) {
+                    NavigationLink(destination: ProfileSettingsView(
+                        viewModel: profileViewModel,
+                        shouldNavigateToProfileView: $shouldNavigateToProfileView,
+                        onComplete: {
+                            shouldNavigateToProfileView = true
+                            dismiss()
+                        }
+                    )) {
                         HStack{
                             Text("프로필 설정")
                                 .fontWeight(.medium)
@@ -94,7 +101,7 @@ struct SettingsView: View {
         }
     }
 }
-
-//#Preview {
-//    SettingsView(profileViewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
-//}
+    
+    //#Preview {
+    //    SettingsView(profileViewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
+    //}

--- a/Kabinett/Presentation/View/Profile/SettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/SettingsView.swift
@@ -34,7 +34,7 @@ struct SettingsView: View {
                     }
                     .buttonStyle(PlainButtonStyle())
                     
-                    NavigationLink(destination: AccountSettingsView()) {
+                    NavigationLink(destination: AccountSettingsView(profileViewModel: profileViewModel)) {
                         HStack{
                             Text("계정 설정")
                                 .fontWeight(.medium)
@@ -58,7 +58,7 @@ struct SettingsView: View {
                             Image(systemName: "apple.logo")
                                 .font(.system(size: 14))
                                 .foregroundColor(.white)
-                        }
+                        } //추후에 다른 소셜로그인 추가되면 이미지 변경 가능하게 수정하기
                         .padding(.leading, 10)
                         Text(profileViewModel.appleID)
                             .font(.system(size: 17))
@@ -68,7 +68,6 @@ struct SettingsView: View {
                     
                     Spacer()
                 }
-                .buttonStyle(PlainButtonStyle())
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.background)
                 .navigationTitle("설정")

--- a/Kabinett/Presentation/View/Profile/SettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/SettingsView.swift
@@ -10,13 +10,14 @@ import SwiftUI
 struct SettingsView: View {
     @ObservedObject var profileViewModel: ProfileSettingsViewModel
     @Environment(\.dismiss) var dismiss
-    @State private var shouldNavigateToProfileView = false
+    @Binding var shouldNavigateToProfileView: Bool
+    var onAccountActionComplete: () -> Void
     
     var body: some View {
         GeometryReader { geometry in
             NavigationStack {
                 VStack(alignment: .leading) {
-                    NavigationLink(destination: ProfileSettingsView(viewModel: profileViewModel, shouldNavigateToProfileView: $shouldNavigateToProfileView)) {
+                    NavigationLink(destination: ProfileSettingsView(viewModel: profileViewModel,shouldNavigateToProfileView: $shouldNavigateToProfileView)) {
                         HStack{
                             Text("프로필 설정")
                                 .fontWeight(.medium)
@@ -34,7 +35,10 @@ struct SettingsView: View {
                     }
                     .buttonStyle(PlainButtonStyle())
                     
-                    NavigationLink(destination: AccountSettingsView(profileViewModel: profileViewModel)) {
+                    
+                    NavigationLink(destination: AccountSettingsView(profileViewModel: profileViewModel, onComplete: {
+                        onAccountActionComplete()
+                    })) {
                         HStack{
                             Text("계정 설정")
                                 .fontWeight(.medium)
@@ -91,6 +95,6 @@ struct SettingsView: View {
     }
 }
 
-#Preview {
-    SettingsView(profileViewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
-}
+//#Preview {
+//    SettingsView(profileViewModel: ProfileSettingsViewModel(profileUseCase: ProfileUseCaseStub()))
+//}

--- a/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
@@ -30,7 +30,7 @@ class ProfileSettingsViewModel: ObservableObject {
     @Published var profileUpdateError: String?
     @Published var showProfileAlert = false
     @Published var isLoggedOut = false
-    @Published var isDeleteID = false
+    @Published var isDeletedAccount = false
     
     init(profileUseCase: ProfileUseCase) {
         self.profileUseCase = profileUseCase
@@ -165,6 +165,8 @@ class ProfileSettingsViewModel: ObservableObject {
         let success = await profileUseCase.signout()
         if success {
             isLoggedOut = true
+        } else {
+            print("로그아웃에 실패했어요.")
         }
     }
     
@@ -172,7 +174,9 @@ class ProfileSettingsViewModel: ObservableObject {
     func deletieID() async {
         let success = await profileUseCase.deleteId()
         if success {
-            isDeleteID = true
+            isDeletedAccount = true
+        } else {
+            print("회원탈퇴에 실패했어요.")
         }
     }
 }

--- a/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
@@ -29,6 +29,8 @@ class ProfileSettingsViewModel: ObservableObject {
     @Published var shouldNavigateToProfile: Bool = false
     @Published var profileUpdateError: String?
     @Published var showProfileAlert = false
+    @Published var isLoggedOut = false
+    @Published var isDeleteID = false
     
     init(profileUseCase: ProfileUseCase) {
         self.profileUseCase = profileUseCase
@@ -155,6 +157,22 @@ class ProfileSettingsViewModel: ObservableObject {
         DispatchQueue.main.async {
             self.croppedImage = croppedImage
             self.isShowingCropper = false
+        }
+    }
+    
+    @MainActor
+    func signout() async {
+        let success = await profileUseCase.signout()
+        if success {
+            isLoggedOut = true
+        }
+    }
+    
+    @MainActor
+    func deletieID() async {
+        let success = await profileUseCase.deleteId()
+        if success {
+            isDeleteID = true
         }
     }
 }

--- a/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/Profile/ProfileSettingsViewModel.swift
@@ -41,7 +41,7 @@ class ProfileSettingsViewModel: ObservableObject {
             await fetchAppleID()
         }
     }
-    
+    // TODO: 프로필 이미지 없을 때 탭바 이미지도 설정하기
     @MainActor
     private func loadInitialData() async {
         let writer = await profileUseCase.getCurrentWriter()
@@ -55,7 +55,7 @@ class ProfileSettingsViewModel: ObservableObject {
         } else {
             self.profileImage = nil
         }
-    }// 프로필 이미지 없을 때 탭바 이미지도 설정하기
+    }
     
     @MainActor
     func checkUserStatus() async {


### PR DESCRIPTION
### 📕 Issue Number

Close #71 


### 📙 작업 내역

> 로그아웃과 회원탈퇴 기능 구현
> 로그아웃과 회원탈퇴 후 로그인 화면으로 이동
> 프로필 설정 후 프로필 화면으로 이동

- [x] [AccountSettingsView] 로그아웃 기능 구현
- [x] [AccountSettingsView] 회원탈퇴 기능 구현
- [x] 로그아웃과 회원탈퇴를 마치면 LoginView 로 네비게이션 

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 로그아웃, 회원탈퇴가 실패하는 경우에 대한 테스트는 못해보았어요. 알럿창 하나 띄우면 되는데, 앱 전반적으로 알럿창을 커스텀하면 좋을 것 같아서 MVP 이후에 한번 다 손보면서 테스트도 같이 해볼게요~!

- 원래는 프로필 설정이 끝나면 SettingsView(프로필 설정, 계정 설정 나오는 뷰)로 이동하고 나서 프로필뷰로 이동하는 방식이었는데, 프로필 설정 끝나면 바로 프로필 뷰로 이동하게 수정하였어요. PR 을 새로 파기엔 작아서 여기에 끼워둡니다~~

| ![로그아웃](https://github.com/user-attachments/assets/79eb64d0-7200-4028-9841-c3fb58c67afe) | ![회원탈퇴](https://github.com/user-attachments/assets/7c3d9606-6a1f-48fc-87bb-df5ef7492eeb) | ![프로필설정 네비게이션](https://github.com/user-attachments/assets/7168dfdd-0d01-4da8-a221-5d1c6a91ba78) |
|:---------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------:|
| 로그아웃                                                                                      | 회원탈퇴                                                                                     | 프로필설정 네비게이션                                                                                         |


<br/><br/>