### PR TITLE
Feature/sign up use case

### DIFF
--- a/Kabinett.xcodeproj/project.pbxproj
+++ b/Kabinett.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		83A826CD2C6F2D23006FB09B /* ProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A826CC2C6F2D23006FB09B /* ProfileUseCase.swift */; };
 		83CA92AB2C8160CB00DFB68B /* Publisher+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CA92AA2C8160CB00DFB68B /* Publisher+.swift */; };
 		83CA92AE2C8181DB00DFB68B /* FirestorageWriterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CA92AD2C8181DB00DFB68B /* FirestorageWriterManager.swift */; };
+		83D9C8E52C830C7600EF2684 /* DefaultSignUpUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D9C8E42C830C7600EF2684 /* DefaultSignUpUseCase.swift */; };
 		83F0D6852C705E42001B8733 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F0D6842C705E42001B8733 /* AuthManager.swift */; };
 		83F0D6872C7072DB001B8733 /* FirestoreWriterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F0D6862C7072DB001B8733 /* FirestoreWriterManager.swift */; };
 		AFA58F222C6A004C00A7C569 /* LetterWriteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA58F212C6A004C00A7C569 /* LetterWriteUseCase.swift */; };
@@ -212,6 +213,7 @@
 		83A826CC2C6F2D23006FB09B /* ProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUseCase.swift; sourceTree = "<group>"; };
 		83CA92AA2C8160CB00DFB68B /* Publisher+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+.swift"; sourceTree = "<group>"; };
 		83CA92AD2C8181DB00DFB68B /* FirestorageWriterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestorageWriterManager.swift; sourceTree = "<group>"; };
+		83D9C8E42C830C7600EF2684 /* DefaultSignUpUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSignUpUseCase.swift; sourceTree = "<group>"; };
 		83F0D6842C705E42001B8733 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		83F0D6862C7072DB001B8733 /* FirestoreWriterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreWriterManager.swift; sourceTree = "<group>"; };
 		AFA58F172C69DB1300A7C569 /* Writer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
@@ -495,6 +497,7 @@
 				83F0D6862C7072DB001B8733 /* FirestoreWriterManager.swift */,
 				83949C892C71BC0F0080D72C /* DefaultProfileUseCase.swift */,
 				83CA92AD2C8181DB00DFB68B /* FirestorageWriterManager.swift */,
+				83D9C8E42C830C7600EF2684 /* DefaultSignUpUseCase.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -866,6 +869,7 @@
 				839CE0F72C644BEF003635F3 /* KabinettApp.swift in Sources */,
 				04DEC0FC2C7D96BC00D289EA /* ImageCropper.swift in Sources */,
 				577157012C75D73700E21162 /* Extension+UIApplication.swift in Sources */,
+				83D9C8E52C830C7600EF2684 /* DefaultSignUpUseCase.swift in Sources */,
 				832C72672C71CF7B0071E8D0 /* SignUpUseCase.swift in Sources */,
 				04DEC0EB2C6C87B500D289EA /* AccountSettingsView.swift in Sources */,
 			);

--- a/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
+++ b/Kabinett/Domain/UseCase/SignUpUseCase/SignUpUseCase.swift
@@ -14,7 +14,7 @@ enum SignUpResult {
     case signInOnly
 }
 
-protocol SignupUseCase {
+protocol SignUpUseCase {
     func getAvailableKabinettNumbers() async -> [Int]
     func signUp(
         _ authorization: ASAuthorization
@@ -25,7 +25,7 @@ protocol SignupUseCase {
     ) async -> Bool
 }
 
-final class SignUpUseCaseStub: SignupUseCase {
+final class SignUpUseCaseStub: SignUpUseCase {
     func getAvailableKabinettNumbers() async -> [Int] {
         [1, 100000, 445544]
     }

--- a/Kabinett/Presentation/ViewModel/SignUp/SignUpViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/SignUp/SignUpViewModel.swift
@@ -11,7 +11,7 @@ import AuthenticationServices
 import CryptoKit
 
 final class SignUpViewModel: ObservableObject {
-    private let signUpUseCase: any SignupUseCase
+    private let signUpUseCase: any SignUpUseCase
     
     @Published var profileViewModel: ProfileSettingsViewModel?
     @Published var userName: String = ""
@@ -25,7 +25,7 @@ final class SignUpViewModel: ObservableObject {
     @Published var signUpSuccess: Bool = false
     @Published var showAlert: Bool = false
     
-    init(signUpUseCase: any SignupUseCase) {
+    init(signUpUseCase: any SignUpUseCase) {
         self.signUpUseCase = signUpUseCase
     }
     

--- a/Kabinett/Service/Auth/AuthManager.swift
+++ b/Kabinett/Service/Auth/AuthManager.swift
@@ -87,11 +87,17 @@ final class AuthManager {
         }
     }
 
-    private func signInWith(credential: AuthCredential) async {
+    // MARK: - Private Methods
+    private func signInWith(
+        credential: AuthCredential
+    ) async -> User? {
         do {
-            try await Auth.auth().signIn(with: credential)
+            return try await Auth.auth()
+                .signIn(with: credential)
+                .user
         } catch {
             logger.error("signInWith Error: \(error)")
+            return nil
         }
     }
     

--- a/Kabinett/Service/Auth/DefaultSignUpUseCase.swift
+++ b/Kabinett/Service/Auth/DefaultSignUpUseCase.swift
@@ -1,0 +1,101 @@
+//
+//  DefaultSignUpUseCase.swift
+//  Kabinett
+//
+//  Created by jinwoong Kim on 8/31/24.
+//
+
+import Foundation
+import AuthenticationServices
+import os
+
+final class DefaultSignUpUseCase {
+    // MARK: - Properties
+    private let logger: Logger
+    
+    private let authManager: AuthManager
+    private let writerManager: FirestoreWriterManager
+    
+    init(
+        authManager: AuthManager,
+        writerManager: FirestoreWriterManager
+    ) {
+        self.logger = Logger(
+            subsystem: "co.kr.codegrove.Kabinett",
+            category: "DefaultSignUpUseCase"
+        )
+        self.authManager = authManager
+        self.writerManager = writerManager
+    }
+}
+
+// MARK: - Public Methods
+extension DefaultSignUpUseCase: SignUpUseCase {
+    func getAvailableKabinettNumbers() async -> [Int] {
+        var availableNumbers: [Int] = []
+        
+        while true {
+            let randomNumber = Int.random(in: 1..<1_000_000)
+            if await writerManager.checkAvailability(of: randomNumber) {
+                availableNumbers.append(randomNumber)
+            }
+            if availableNumbers.count == 3 { break }
+        }
+        
+        return availableNumbers
+    }
+    
+    func signUp(_ authorization: ASAuthorization) async -> SignUpResult {
+        // TODO: Check this sign-in is success or failed.
+        // TODO: Add nonce as parameter.
+        // let nonce = ""
+        
+        guard let appleIDCrendential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            logger.error("This Credential is not valid.")
+            return .newUser
+        }
+        guard let appleIDToken = appleIDCrendential.identityToken else {
+            logger.error("Cannot fetch id token from crendential.")
+            return .newUser
+        }
+        guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+            logger.error("Cannot parse id token string from toke: \(appleIDToken.debugDescription)")
+            return .newUser
+        }
+        let result = await authManager.linkAccount(with: idTokenString)
+        
+        switch result {
+        case .newUser:
+            return .newUser
+        case let .existingUser(user):
+            let writer = await writerManager
+                .getWriterDocument(with: user?.uid ?? "")
+            
+            if writer.kabinettNumber == 0 {
+                return .signInOnly
+            } else {
+                return .registered
+            }
+        }
+    }
+    
+    func startLoginUser(
+        with userName: String,
+        kabinettNumber: Int
+    ) async -> Bool {
+        guard let currentUser = authManager.getCurrentUser() else {
+            logger.error("There is no user now.")
+            return false
+        }
+        let writer = Writer(
+            name: userName,
+            kabinettNumber: kabinettNumber,
+            profileImage: nil
+        )
+        
+        return writerManager.saveWriterDocument(
+            with: writer,
+            to: currentUser.uid
+        )
+    }
+}

--- a/Kabinett/Service/Auth/FirestoreWriterManager.swift
+++ b/Kabinett/Service/Auth/FirestoreWriterManager.swift
@@ -42,4 +42,17 @@ final class FirestoreWriterManager {
             return .anonymousWriter
         }
     }
+    
+    func checkAvailability(of number: Int) async -> Bool {
+        do {
+            let result = try await db.collection("Writers")
+                .whereField("kabinettNumber", isEqualTo: number)
+                .limit(to: 1)
+                .getDocuments()
+            return result.isEmpty
+        } catch {
+            logger.error("Number checking Error: \(error)")
+            return false
+        }
+    }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #83 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] `SignUpUseCase`의 구현체 개발


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 애플 로그인 과정에서 `nonce`정보를 사용하려고 했었는데, 그걸 위해서 `nonce`정보를 유즈케이스에 추가해야할 것 같아요.
```swift
func signUp(_ authorization: ASAuthorization) async -> SignUpResult
// to
func signUp(_ authorization: ASAuthorization, nonce: String?) async -> SignUpResult
```
- 애플 로그인 자제를 실패했을 때에 대한 이야기를 해보아야할 것 같아요...
- 과정중, 테스트를 제대로 못해봤어요. 문제가 자주 발생할 것 같으니.. 문제가 발생시 꼭 @jinwoong16 에게 알려주세요!

<br/><br/>