### PR TITLE
Fix: 익명유저가 편지를 작성하지 못하는 현상 수정

### DIFF
--- a/Kabinett/Service/Letter/DefaultNormalLetterUseCase.swift
+++ b/Kabinett/Service/Letter/DefaultNormalLetterUseCase.swift
@@ -109,10 +109,7 @@ extension DefaultNormalLetterUseCase: LetterWriteUseCase {
             .getCurrentUser()
             .compactMap { $0 }
             .asyncMap { [weak self] user in
-                if user.isAnonymous { return .anonymousWriter }
-                else {
-                    return await self?.writerManager.getWriterDocument(with: user.uid)
-                }
+                await self?.writerManager.getWriterDocument(with: user.uid)
             }
             .compactMap { $0 }
             .eraseToAnyPublisher()


### PR DESCRIPTION
### 📕 Issue Number

Close #130 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 익명 유저가 편지 작성되게 수정


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 익명 로그인 상태인지 아닌지에 따라서 현재 `Writer`를 반환하는데 문제가 있었어요. 익명 로그인 상태면 그냥 쌩 `Writer`를 만들어서 반환했는데 여기가 문제였습니다~

<br/><br/>