### PR TITLE
Fix: 재로그인시, 크래시나는 현상 수정

### DIFF
--- a/Kabinett/Service/Auth/AuthManager.swift
+++ b/Kabinett/Service/Auth/AuthManager.swift
@@ -92,8 +92,10 @@ final class AuthManager {
             
             if code == .credentialAlreadyInUse {
                 logger.debug("This credential already in use, delete current user and retry signing.")
-                
-                let existingUser = await signInWith(credential: credential)
+                guard let newCredential = error.userInfo[AuthErrorUserInfoUpdatedCredentialKey] as? OAuthCredential else {
+                    fatalError("Credential failed")
+                }
+                let existingUser = await signInWith(credential: newCredential)
                 await deleteAccount(of: user)
                 
                 return .existingUser(existingUser)


### PR DESCRIPTION
### 📕 Issue Number

Close #143 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 재로그인 시도시, 크래시나는 현상 수정


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 애플 로그인은 기존의 credential로 다시 로그인을 시도할 수 없다고 합니다. 한번 에러를 발생시키고... 그 에러에 담겨오는 새로운 credential을 사용해서 다시 로그인을 시도해야 하더라구요. 이렇게 해서 문제는 해결했습니다.

<br/><br/>