### PR TITLE
Feat: heic 이미지의 회전 정보(EXIF)를 무시하여 크롭 오류 해결

### DIFF
--- a/Kabinett/Presentation/View/Profile/ImageCropper.swift
+++ b/Kabinett/Presentation/View/Profile/ImageCropper.swift
@@ -17,11 +17,13 @@ struct ImageCropper: View {
 
     var body: some View {
         if let imageToCrop = imageToCrop {
+            let normalizedImage = imageToCrop.normalized()
+
             VStack {
                 Spacer()
-                imageView(image: imageToCrop)
+                imageView(image: normalizedImage)
                 Spacer()
-                actionButtons(image: imageToCrop)
+                actionButtons(image: normalizedImage)
                 if let croppedImage = croppedImage {
                     croppedImageView(croppedImage: croppedImage)
                 }
@@ -90,5 +92,20 @@ struct ImageCropper: View {
             .resizable()
             .scaledToFit()
             .frame(width: 110)
+    }
+}
+
+extension UIImage {
+    func normalized() -> UIImage {
+        if self.imageOrientation == .up {
+            return self
+        }
+        
+        UIGraphicsBeginImageContextWithOptions(self.size, false, self.scale) // 새로운 캔버스 만들기
+        self.draw(in: CGRect(origin: .zero, size: self.size)) // heic의 이미지 회전 정보를 무시하고 새로 그림
+        let normalizedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return normalizedImage ?? self
     }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #211 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] heic 이미지 크롭 문제 해결

### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 문제의 원인: heic는 EXIF라는 메타데이터가 포함되어 있고, 이 안에 Orientation 정보가 있어요. 이 회전 정보가 잘못되었을 때 크롭하면 회전된 채로 크롭이 적용되어 이상한 결과값이 나오는 것이었습니다..! (정사각형 이미지는 해당 오류가 없는 것으로보아 회전정보 자체를 기록하지 않는 것 같다는 개인적인 생각...

- 문제의 해결: 이미지의 회전정보를 무시하고 새로운 캔버스에 이미지를 그리고 그 이미지를 크롭하는 방법으로 해결하였어요. `UIGraphicsBeginImageContextWithOptions`를 사용하였어요. UIKit의 기본 제공 함수로, 새로운 그래픽을 그릴 수 있게 해주는 캔버스 역할을 해준다고 해요.

<br/><br/>