### PR TITLE
Fix: 프로필 이미지 세팅 아이콘 변경

### DIFF
--- a/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileSettingsView.swift
@@ -95,9 +95,16 @@ struct ProfileSettingsView: View {
                         .frame(width: 110, height: 110)
                         .clipShape(Circle())
                 }
-                Image(systemName: "photo")
-                    .font(.system(size: 36))
-                    .foregroundColor(.white)
+                ZStack {
+                    Circle()
+                        .foregroundStyle(.primary900)
+                        .frame(width: 35, height: 35)
+                    Image(systemName: "pencil")
+                        .font(.system(size: 20))
+                        .fontWeight(.heavy)
+                        .foregroundColor(.white)
+                }
+                .offset(x: 37, y: 35)
             }
         }
         .onChange(of: viewModel.selectedImageItem) { oldItem, newItem in


### PR DESCRIPTION
### 📕 Issue Number

Close #


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 프로필 이미지 세팅뷰 아이콘 변경


### 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

| <img width="492" alt="스크린샷 2024-11-09 오후 1 45 43" src="https://github.com/user-attachments/assets/c5b0e2db-b895-4603-b779-6fee5981c010"> | <img width="464" alt="스크린샷 2024-11-09 오후 1 49 04" src="https://github.com/user-attachments/assets/864bbeeb-b53e-4187-8f97-3a6a329fbd2b"> |
|----------|----------|
| 16pro | SE |


<br/><br/>