### PR TITLE
Fix: Resetting the view on tab clicks

### DIFF
--- a/Kabinett/Presentation/Commons/CustomTabView/CustomTabView.swift
+++ b/Kabinett/Presentation/Commons/CustomTabView/CustomTabView.swift
@@ -30,13 +30,13 @@ struct CustomTabView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             TabView(selection: $customTabViewModel.selectedTab) {
-                LetterBoxView()
+                LetterBoxView(customTabViewModel: customTabViewModel)
                     .tag(0)
                 
                 Color.clear
                     .tag(1)
                 
-                ProfileView()
+                ProfileView(customTabViewModel: customTabViewModel)
                     .tag(2)
             }
             .overlay(

--- a/Kabinett/Presentation/Commons/CustomTabViewModel/CustomTabViewModel.swift
+++ b/Kabinett/Presentation/Commons/CustomTabViewModel/CustomTabViewModel.swift
@@ -20,7 +20,7 @@ final class CustomTabViewModel: ObservableObject {
     @Published var isLetterWrite: Bool = false
     @Published var previousTab: Int?
     
-    static let profileTabTappedNotification = Notification.Name("profileTabTapped")
+    static let resetProfileNavigationNotification = Notification.Name("resetProfileNavigation")
     
     private var lastTabSelectionTime: Date?
     private let doubleTapInterval: TimeInterval = 0.2
@@ -50,30 +50,24 @@ final class CustomTabViewModel: ObservableObject {
     }
     
     func handleTabSelection(_ tab: Int) {
-            if tab == selectedTab {
-                if tab == 2 {
-                    NotificationCenter.default.post(name: CustomTabViewModel.profileTabTappedNotification, object: nil)
-                }
-                if tab == 0 {
-                    letterBoxNavigationPath.removeLast(letterBoxNavigationPath.count)
-                }
-            } else if tab == 1 {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    showOptions = true
-                }
-            } else {
-                selectedTab = tab
+        if tab == selectedTab {
+            if tab == 2 {
+                NotificationCenter.default.post(name: CustomTabViewModel.resetProfileNavigationNotification, object: nil)
             }
-        }
-    
-    private func resetNavigationForTab(_ tab: Int) {
-        switch tab {
-        case 0:
-            letterBoxNavigationPath.removeLast(letterBoxNavigationPath.count)
-        case 2:
-            profileNavigationPath.removeLast(profileNavigationPath.count)
-        default:
-            break
+            if tab == 0 {
+                letterBoxNavigationPath.removeLast(letterBoxNavigationPath.count)
+            }
+        } else if tab == 1 {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                showOptions = true
+            }
+        } else {
+            selectedTab = tab
+            if tab == 0 {
+                letterBoxNavigationPath.removeLast(letterBoxNavigationPath.count)
+            } else if tab == 2 {
+                profileNavigationPath.removeLast(profileNavigationPath.count)
+            }
         }
     }
     

--- a/Kabinett/Presentation/View/Profile/ProfileView.swift
+++ b/Kabinett/Presentation/View/Profile/ProfileView.swift
@@ -12,8 +12,11 @@ import Kingfisher
 struct ProfileView: View {
     //
     @StateObject private var viewModel: ProfileViewModel
+    @ObservedObject var customTabViewModel: CustomTabViewModel
     
-    init() {
+    init(customTabViewModel: CustomTabViewModel) {
+        self.customTabViewModel = customTabViewModel
+        
         @Injected(ProfileUseCaseKey.self)
         var profileUseCase: ProfileUseCase
         
@@ -23,7 +26,7 @@ struct ProfileView: View {
     }
     
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $customTabViewModel.profileNavigationPath) {
             Group {
                 if case .toLogin = viewModel.navigateState {
                     SignUpView()
@@ -31,13 +34,13 @@ struct ProfileView: View {
                     ZStack {
                         Color.background.ignoresSafeArea(.all)
                         if viewModel.profileUpdateError != nil {
-//                            VStack {
-//                                Text("프로필을 불러오는 데 문제가 발생했어요.")
-//                                    .fontWeight(.regular)
-//                                    .foregroundColor(.alert)
-//                                    .font(.headline)
-//                                    .padding()
-//                            }
+                            //                            VStack {
+                            //                                Text("프로필을 불러오는 데 문제가 발생했어요.")
+                            //                                    .fontWeight(.regular)
+                            //                                    .foregroundColor(.alert)
+                            //                                    .font(.headline)
+                            //                                    .padding()
+                            //                            }
                         } else {
                             VStack {
                                 if let image = viewModel.currentWriter.imageUrlString {
@@ -94,6 +97,9 @@ struct ProfileView: View {
             .navigationDestination(isPresented: $viewModel.showSettingsView) {
                 SettingsView(viewModel: viewModel)
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: CustomTabViewModel.resetProfileNavigationNotification)) { _ in
+            viewModel.showSettingsView = false
         }
     }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #227 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 탭 클릭 시 각 뷰의 네비게이션 스택 초기화


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 저번 PR에서 ProfileView와 LetterBoxView의 Navigation 관련 코드가 누락되어 추가했습니다.

수정사항:
- ProfileView와 LetterBoxView에 CustomTabViewModel 주입
  - ObservedObject customTabViewModel 추가
  - 각 View의 init에 customTabViewModel 파라미터 추가

- LetterBoxView:
  - NavigationStack에 customTabViewModel.letterBoxNavigationPath 바인딩 추가
  - NavigationLink를 destination 방식에서 value 방식으로 변경
  - navigationDestination 모디파이어를 통해 타입 기반 네비게이션 구현
  
- ProfileView:
  - 탭 클릭 시 네비게이션 리셋 기능 추가
  - NotificationCenter를 통한 resetProfileNavigation 구현


<br/><br/>