### PR TITLE
Feature/0403LetterSendToast

### DIFF
--- a/Kabinett.xcodeproj/project.pbxproj
+++ b/Kabinett.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		83D9C8E52C830C7600EF2684 /* DefaultSignUpUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D9C8E42C830C7600EF2684 /* DefaultSignUpUseCase.swift */; };
 		83F0D6852C705E42001B8733 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F0D6842C705E42001B8733 /* AuthManager.swift */; };
 		83F0D6872C7072DB001B8733 /* FirestoreWriterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F0D6862C7072DB001B8733 /* FirestoreWriterManager.swift */; };
+		AF738DC42D50B3900081FB96 /* Extension+NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF738DC32D50B3900081FB96 /* Extension+NotificationName.swift */; };
+		AF738DC62D50B3C00081FB96 /* ToastViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF738DC52D50B3C00081FB96 /* ToastViewModel.swift */; };
 		AF9B18F82C894B5900F3E446 /* DefaultImportLetterUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9B18F72C894B5900F3E446 /* DefaultImportLetterUseCase.swift */; };
 		AF9B18FA2C894B7100F3E446 /* DefaultLetterBoxUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9B18F92C894B7100F3E446 /* DefaultLetterBoxUseCase.swift */; };
 		AFA58F222C6A004C00A7C569 /* WriteLetterUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA58F212C6A004C00A7C569 /* WriteLetterUseCase.swift */; };
@@ -274,6 +276,8 @@
 		83D9C8E42C830C7600EF2684 /* DefaultSignUpUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSignUpUseCase.swift; sourceTree = "<group>"; };
 		83F0D6842C705E42001B8733 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		83F0D6862C7072DB001B8733 /* FirestoreWriterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreWriterManager.swift; sourceTree = "<group>"; };
+		AF738DC32D50B3900081FB96 /* Extension+NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+NotificationName.swift"; sourceTree = "<group>"; };
+		AF738DC52D50B3C00081FB96 /* ToastViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastViewModel.swift; sourceTree = "<group>"; };
 		AF9B18F72C894B5900F3E446 /* DefaultImportLetterUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImportLetterUseCase.swift; sourceTree = "<group>"; };
 		AF9B18F92C894B7100F3E446 /* DefaultLetterBoxUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLetterBoxUseCase.swift; sourceTree = "<group>"; };
 		AFA58F172C69DB1300A7C569 /* Writer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
@@ -371,6 +375,7 @@
 				57966B992C7D8B45008D650B /* Extension+Date.swift */,
 				57966B9D2C7DB266008D650B /* Extension+TextField.swift */,
 				577C86722C8B8D5700EAB1BE /* Extension+View.swift */,
+				AF738DC32D50B3900081FB96 /* Extension+NotificationName.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -569,8 +574,8 @@
 				536AE7FB2C94881C002A3046 /* Cells */,
 				5381504F2C8AD54A007B1E5A /* Components */,
 				53A482D32C6B4E8600F00A9A /* LetterBoxView.swift */,
-				53A482D72C6C6ACA00F00A9A /* LetterBoxDetailView.swift */,
 				5300DA4D2C7EC2F9005F22EB /* LetterView.swift */,
+				53A482D72C6C6ACA00F00A9A /* LetterBoxDetailView.swift */,
 				534C67B62C7FF85700F0C175 /* LetterContentView.swift */,
 				5358E0782CE1EC7E0089C59F /* PhotoDetailView.swift */,
 			);
@@ -632,6 +637,7 @@
 				53DC1A2E2C7F0FC000575ACC /* LetterViewModel.swift */,
 				53A99EA82C81914B00896AAC /* CalendarViewModel.swift */,
 				5358E0722CE16E630089C59F /* SearchBarViewModel.swift */,
+				AF738DC52D50B3C00081FB96 /* ToastViewModel.swift */,
 			);
 			path = LetterBox;
 			sourceTree = "<group>";
@@ -1063,6 +1069,7 @@
 				AFA58F302C6C4B2A00A7C569 /* LetterBoxUseCase.swift in Sources */,
 				AFA58F222C6A004C00A7C569 /* WriteLetterUseCase.swift in Sources */,
 				8314013F2C69C34500F601FB /* Letter.swift in Sources */,
+				AF738DC42D50B3900081FB96 /* Extension+NotificationName.swift in Sources */,
 				57485D3B2C772332000601BF /* ContentWriteView.swift in Sources */,
 				57EBE5B92C6B399C003ECD7F /* StationerySelectionView.swift in Sources */,
 				57EBE5B02C69E5F2003ECD7F /* UserSelectionView.swift in Sources */,
@@ -1087,6 +1094,7 @@
 				53FC6B822C901F7700E7D9A8 /* Extension+Collection.swift in Sources */,
 				53DC1A2F2C7F0FC000575ACC /* LetterViewModel.swift in Sources */,
 				7F9890822C7EF5C30035CB0D /* CustomTabBar.swift in Sources */,
+				AF738DC62D50B3C00081FB96 /* ToastViewModel.swift in Sources */,
 				8356843D2CE0A43600120EC8 /* ServiceKeys.swift in Sources */,
 				53BB36422C8E943600E74A4D /* CustomStrokePathView.swift in Sources */,
 				5753E0A02CE1AB8200ACC007 /* WriteLetterEnvelopeCell.swift in Sources */,

--- a/Kabinett/Presentation/Utils/Extension/Extension+NotificationName.swift
+++ b/Kabinett/Presentation/Utils/Extension/Extension+NotificationName.swift
@@ -1,0 +1,12 @@
+//
+//  Extension+NotificationName.swift
+//  Kabinett
+//
+//  Created by JIHYE SEOK on 2/3/25.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let showToast = Notification.Name("showToast")
+}

--- a/Kabinett/Presentation/View/ImportLetter/PhotoImporting/ImagePreview.swift
+++ b/Kabinett/Presentation/View/ImportLetter/PhotoImporting/ImagePreview.swift
@@ -52,6 +52,7 @@ struct ImagePreview: View {
                     }
                     .padding(.horizontal, UIScreen.main.bounds.width * 0.06)
                 }
+                .padding(.bottom, LayoutHelper.shared.getSize(forSE: 0.03, forOthers: 0.0))
             }
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)

--- a/Kabinett/Presentation/View/ImportLetter/PhotoImporting/LetterCompletionView.swift
+++ b/Kabinett/Presentation/View/ImportLetter/PhotoImporting/LetterCompletionView.swift
@@ -142,9 +142,10 @@ struct LetterCompletionView: View {
                 }
                 
                 let success = await viewModel.saveImportingImage()
-                if !success {
-                    print("Failed to save letter")
-                }
+                NotificationCenter.default.post(
+                    name: .showToast,
+                    object: nil,
+                    userInfo: success ? ["message": "편지가 성공적으로 보관되었어요.", "color": Color.primary900] : ["message": "앗…!! 편지 보관을 실패했어요..", "color": Color.alert])
             }
         }) {
             Text("편지 보관하기")

--- a/Kabinett/Presentation/View/ImportLetter/PhotoImporting/LetterCompletionView.swift
+++ b/Kabinett/Presentation/View/ImportLetter/PhotoImporting/LetterCompletionView.swift
@@ -157,6 +157,7 @@ struct LetterCompletionView: View {
                 .cornerRadius(16)
         }
         .padding(.horizontal, UIScreen.main.bounds.width * 0.06)
+        .padding(.bottom, LayoutHelper.shared.getSize(forSE: 0.03, forOthers: 0.0))
         .disabled(viewModel.isLoading)
     }
 }

--- a/Kabinett/Presentation/View/ImportLetter/PhotoImporting/LetterCompletionView.swift
+++ b/Kabinett/Presentation/View/ImportLetter/PhotoImporting/LetterCompletionView.swift
@@ -145,7 +145,7 @@ struct LetterCompletionView: View {
                 NotificationCenter.default.post(
                     name: .showToast,
                     object: nil,
-                    userInfo: success ? ["message": "편지가 성공적으로 보관되었어요.", "color": Color.primary900] : ["message": "앗…!! 편지 보관을 실패했어요..", "color": Color.alert])
+                    userInfo: success ? ["message": "편지가 성공적으로 보관되었어요.", "color": Color.primary900] : ["message": "앗..!! 편지 보관을 실패했어요..", "color": Color.alert])
             }
         }) {
             Text("편지 보관하기")

--- a/Kabinett/Presentation/View/LetterBox/Components/ToastView.swift
+++ b/Kabinett/Presentation/View/LetterBox/Components/ToastView.swift
@@ -8,22 +8,20 @@
 import SwiftUI
 
 struct ToastView: View {
-    let message: String
-    @Binding var showToast: Bool
-    
+    @ObservedObject var toastViewModel: ToastViewModel
     @State private var actualCurrentOffset: CGSize = CGSize(width: 0, height: UIScreen.main.bounds.height)
     
     var body: some View {
-        if showToast {
+        if toastViewModel.showToast {
             ZStack {
                 Rectangle()
                     .fill(.clear)
-                    .background(.primary900)
+                    .background(toastViewModel.backgroundColor)
                     .frame(height: 50)
                     .cornerRadius(28)
                     .padding(.horizontal, 50)
                 
-                Text(message)
+                Text(toastViewModel.message)
                     .font(.system(size: 16, weight: .heavy))
                     .foregroundStyle(.white)
             }
@@ -34,15 +32,11 @@ struct ToastView: View {
                 } completion: {
                     withAnimation(Animation.easeInOut(duration: 1.5).delay(1.2)) {
                         actualCurrentOffset = CGSize(width: 0, height: UIScreen.main.bounds.height)
-                        showToast = false
+                        toastViewModel.showToast = false
                     }
                 }
             }
             .padding(.bottom, LayoutHelper.shared.getSize(forSE: 0.01, forOthers: 0.01))
         }
     }
-}
-
-#Preview {
-    ToastView(message: "카비넷 팀이 보낸 편지가 도착했어요.", showToast: .constant(true))
 }

--- a/Kabinett/Presentation/View/LetterBox/LetterBoxView.swift
+++ b/Kabinett/Presentation/View/LetterBox/LetterBoxView.swift
@@ -16,6 +16,7 @@ struct LetterBoxView: View {
     
     @StateObject private var calendarViewModel = CalendarViewModel()
     @StateObject private var searchBarViewModel = SearchBarViewModel()
+    @StateObject private var toastViewModel = ToastViewModel()
     
     @ObservedObject var customTabViewModel: CustomTabViewModel
     
@@ -57,7 +58,7 @@ struct LetterBoxView: View {
                     
                     VStack {
                         Spacer()
-                        ToastView(message: "카비넷 팀의 편지가 도착했어요.", showToast: $letterBoxViewModel.showToast)
+                        ToastView(toastViewModel: toastViewModel)
                     }
                 }
                 .onAppear() {

--- a/Kabinett/Presentation/View/WriteLetter/ContentWriteView.swift
+++ b/Kabinett/Presentation/View/WriteLetter/ContentWriteView.swift
@@ -48,6 +48,7 @@ struct ContentWriteView: View {
                         .background(Color(.primary900).opacity(0.3))
                         .clipShape(Capsule())
                 }
+                .padding(.bottom, LayoutHelper.shared.getSize(forSE: 0.03, forOthers: 0.0))
                 MiniTabBarView(letterContent: $letterContent, viewModel: viewModel, customTabViewModel: customTabViewModel)
                 
                 if keyBoard {

--- a/Kabinett/Presentation/View/WriteLetter/PreviewLetterView.swift
+++ b/Kabinett/Presentation/View/WriteLetter/PreviewLetterView.swift
@@ -82,6 +82,7 @@ struct PreviewLetterView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 16))
             }
             .padding(.horizontal, UIScreen.main.bounds.width * 0.06)
+            .padding(.bottom, LayoutHelper.shared.getSize(forSE: 0.03, forOthers: 0.0))
         }
         .ignoresSafeArea(.keyboard)
         .analyticsScreen(

--- a/Kabinett/Presentation/ViewModel/LetterBox/LetterBoxViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/LetterBox/LetterBoxViewModel.swift
@@ -16,7 +16,7 @@ class LetterBoxViewModel: ObservableObject {
     
     @Published var letterBoxLetters: [LetterType: [Letter]] = [:]
     @Published var isReadLetters: [LetterType: Int] = [:]
-    @Published var showToast = false
+    @Published var isShowToast = false
     
     @Published var errorMessage: String?
     
@@ -70,9 +70,13 @@ class LetterBoxViewModel: ObservableObject {
             let result = await letterBoxUseCase.getWelcomeLetter()
             switch result {
             case .success:
-                self.showToast = true
+                self.isShowToast = true
+                NotificationCenter.default.post(
+                    name: .showToast,
+                    object: nil,
+                    userInfo: ["message": "카비넷 팀의 편지가 도착했어요.", "color": Color.primary900])
             case .failure(let error):
-                self.showToast = false
+                self.isShowToast = false
                 self.errorMessage = error.localizedDescription
             }
         }

--- a/Kabinett/Presentation/ViewModel/LetterBox/LetterBoxViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/LetterBox/LetterBoxViewModel.swift
@@ -74,7 +74,7 @@ class LetterBoxViewModel: ObservableObject {
                 NotificationCenter.default.post(
                     name: .showToast,
                     object: nil,
-                    userInfo: ["message": "카비넷 팀의 편지가 도착했어요.", "color": Color.primary900])
+                    userInfo: ["message": "카비넷 팀이 보낸 편지가 도착했어요.", "color": Color.primary900])
             case .failure(let error):
                 self.isShowToast = false
                 self.errorMessage = error.localizedDescription

--- a/Kabinett/Presentation/ViewModel/LetterBox/ToastViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/LetterBox/ToastViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  ToastViewModel.swift
+//  Kabinett
+//
+//  Created by JIHYE SEOK on 2/3/25.
+//
+
+import Foundation
+import SwiftUI
+
+class ToastViewModel: ObservableObject {
+    @Published var message: String = ""
+    @Published var showToast: Bool = false
+    @Published var backgroundColor: Color = .primary900
+    
+    init() {
+        setupNotification()
+    }
+    
+    private func setupNotification() {
+        NotificationCenter.default.addObserver(
+            forName: .showToast,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            if let message = notification.userInfo?["message"] as? String,
+               let color = notification.userInfo?["color"] as? Color {
+                self?.showToast(message: message, color: color)
+            }
+        }
+    }
+    
+    private func showToast(message: String, color: Color) {
+        self.message = message
+        self.backgroundColor = color
+        showToast = true
+    }
+}

--- a/Kabinett/Presentation/ViewModel/WriteLetter/PreviewLetterViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/WriteLetter/PreviewLetterViewModel.swift
@@ -62,6 +62,11 @@ class PreviewLetterViewModel: ObservableObject {
                     self.errorMessage = "오류 발생: \(error.localizedDescription)"
                     print("Save Letter Error: \(error.localizedDescription)")
                 }
+                
+                NotificationCenter.default.post(
+                    name: .showToast,
+                    object: nil,
+                    userInfo: isSaveSuccessful ? ["message": "편지가 성공적으로 보관되었어요.", "color": Color.primary900] : ["message": "앗…!! 편지 보관을 실패했어요..", "color": Color.alert])
             }
         }
     }

--- a/Kabinett/Presentation/ViewModel/WriteLetter/PreviewLetterViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/WriteLetter/PreviewLetterViewModel.swift
@@ -66,7 +66,7 @@ class PreviewLetterViewModel: ObservableObject {
                 NotificationCenter.default.post(
                     name: .showToast,
                     object: nil,
-                    userInfo: isSaveSuccessful ? ["message": "편지가 성공적으로 보관되었어요.", "color": Color.primary900] : ["message": "앗…!! 편지 보관을 실패했어요..", "color": Color.alert])
+                    userInfo: isSaveSuccessful ? ["message": "편지가 성공적으로 전송되었어요.", "color": Color.primary900] : ["message": "앗…!! 편지 전송을 실패했어요..", "color": Color.alert])
             }
         }
     }

--- a/Kabinett/Presentation/ViewModel/WriteLetter/PreviewLetterViewModel.swift
+++ b/Kabinett/Presentation/ViewModel/WriteLetter/PreviewLetterViewModel.swift
@@ -66,7 +66,7 @@ class PreviewLetterViewModel: ObservableObject {
                 NotificationCenter.default.post(
                     name: .showToast,
                     object: nil,
-                    userInfo: isSaveSuccessful ? ["message": "편지가 성공적으로 전송되었어요.", "color": Color.primary900] : ["message": "앗…!! 편지 전송을 실패했어요..", "color": Color.alert])
+                    userInfo: isSaveSuccessful ? ["message": "편지가 성공적으로 전송되었어요.", "color": Color.primary900] : ["message": "앗..!! 편지 전송을 실패했어요..", "color": Color.alert])
             }
         }
     }


### PR DESCRIPTION
### 📕 Issue Number

Close #286


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 편지 전송/보관 알림 기능
- [x] iPhone SE bottom 패딩 조정

### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- NotificationCenter를 활용하여 편지 전송 및 보관에 관련된 알림 피드백을 추가하였습니다.
- SE의 경우 bottom padding을 0.03을 주었습니다. 더 올리고 싶거나 내리고 싶으면 숫자를 변동하면 됩니다.
- 서비스 화면의 경우 성공알림은 iPhoneSE, 실패알림은 iPhone15로 녹화하였습니다.

### 📱 서비스 화면
| **편지쓰기(성공)** | **편지쓰기(실패)** | **편지보관(성공)** | **편지보관(실패)** |
|:-----------------:|:------------------:|:-------------------:|:-------------------:|
| ![편지쓰기성공](https://github.com/user-attachments/assets/5aba5b6b-ce46-465b-869b-cf20f884462e) | ![편지쓰기실패](https://github.com/user-attachments/assets/80cc8529-56d0-4ea9-8ed5-4b0854b1bb8a) | ![편지보관성공](https://github.com/user-attachments/assets/5e1241c8-fbe7-4223-b833-34782420618d) | ![편지보관실패](https://github.com/user-attachments/assets/8f1de17c-8c48-418a-bcd6-72f5619b2be9) |

<br/><br/>